### PR TITLE
DdlParser does not handle end-of-line comments correctly

### DIFF
--- a/src/test/java/io/ebean/dbmigration/ddl/DdlParserTest.java
+++ b/src/test/java/io/ebean/dbmigration/ddl/DdlParserTest.java
@@ -14,34 +14,28 @@ public class DdlParserTest {
   public void parse_ignoresEmptyLines() throws Exception {
 
     List<String> stmts = parser.parse(new StringReader("\n\none;\n\ntwo;\n\n"));
-
-    assertThat(stmts).hasSize(2);
-    assertThat(stmts).contains("one;","two;");
+    assertThat(stmts).containsExactly("one;","two;");
   }
 
   @Test
   public void parse_ignoresComments_whenFirst() throws Exception {
 
     List<String> stmts = parser.parse(new StringReader("-- comment\ntwo;"));
-
-    assertThat(stmts).hasSize(1);
-    assertThat(stmts).contains("two;");
+    assertThat(stmts).containsExactly("two;");
   }
 
   @Test
   public void parse_ignoresEmptyLines_whenFirst() throws Exception {
 
     List<String> stmts = parser.parse(new StringReader("\n\n-- comment\ntwo;\n\n"));
-    assertThat(stmts).hasSize(1);
-    assertThat(stmts).contains("two;");
+    assertThat(stmts).containsExactly("two;");
   }
 
   @Test
   public void parse_inlineEmptyLines_replacedWithSpace() throws Exception {
 
     List<String> stmts = parser.parse(new StringReader("\n\n-- comment\none\ntwo;\n\n"));
-    assertThat(stmts).hasSize(1);
-    assertThat(stmts).contains("one two;");
+    assertThat(stmts).containsExactly("one two;");
   }
 
 
@@ -49,13 +43,12 @@ public class DdlParserTest {
   public void parse_ignoresComments() throws Exception {
 
     List<String> stmts = parser.parse(new StringReader("one;\n-- comment\ntwo;"));
-
-    assertThat(stmts).hasSize(2);
-    assertThat(stmts).contains("one;","two;");
+    assertThat(stmts).containsExactly("one;","two;");
   }
 
   @Test
   public void parse_ignoresEndOfLineComments() throws Exception {
+
     List<String> stmts = parser.parse(new StringReader("one; -- comment\ntwo;"));
     assertThat(stmts).containsExactly("one;", "two;");
   }

--- a/src/test/java/io/ebean/dbmigration/ddl/DdlParserTest.java
+++ b/src/test/java/io/ebean/dbmigration/ddl/DdlParserTest.java
@@ -1,10 +1,8 @@
 package io.ebean.dbmigration.ddl;
 
-import org.testng.annotations.Test;
-
 import java.io.StringReader;
 import java.util.List;
-
+import org.testng.annotations.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DdlParserTest {
@@ -54,5 +52,11 @@ public class DdlParserTest {
 
     assertThat(stmts).hasSize(2);
     assertThat(stmts).contains("one;","two;");
+  }
+
+  @Test
+  public void parse_ignoresEndOfLineComments() throws Exception {
+    List<String> stmts = parser.parse(new StringReader("one; -- comment\ntwo;"));
+    assertThat(stmts).containsExactly("one;", "two;");
   }
 }


### PR DESCRIPTION
I just noticed this when it was causing a statement from my migration not to run:

```
update blabla ...; -- something helpful
alter table ...
```

The comment ends up prepended to the second statement, turning it into a comment.

This patch just adds a test. Not sure what the best fix is, as just looking for a "--" anywhere in the line could also match in a quoted string (even though that is somewhat unlikely) or how exactly you want to handle it within stored procs.

A simple fix might be to to join multiple lines of a statement with "\n" rather than " ", so that if a comment does pass through subsequent lines don't get merged into the comment (which is what happened in my migration case) and the driver /db itself will handle it.
