### PR TITLE
Load migration table rows in order

### DIFF
--- a/src/main/java/io/ebean/dbmigration/runner/MigrationMetaRow.java
+++ b/src/main/java/io/ebean/dbmigration/runner/MigrationMetaRow.java
@@ -59,6 +59,7 @@ class MigrationMetaRow {
     runTime = row.getLong(9);
   }
 
+  @Override
   public String toString() {
     return "id:" + id + " type:" + type + " runVersion:" + version + " comment:" + comment + " runOn:" + runOn + " runBy:" + runBy;
   }
@@ -103,7 +104,7 @@ class MigrationMetaRow {
    * Return the SQL insert given the table migration meta data is stored in.
    */
   static String selectSql(String table, String platform) {
-    String sql = "select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from " + table;
+    String sql = "select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from " + table + " order by id";
     if (SQLSERVER.equals(platform)) {
       return sql + " with (updlock)";
     } else {


### PR DESCRIPTION
MigrationTable assumes that the last row read is the one with the highest id
and then uses that id +1 to when inserting a new row. Adding the 'order by'
clause ensures this actually works in all cases.