### PR TITLE
FIX: select from db_migration statement for sqlserver

### DIFF
--- a/src/main/java/io/ebean/dbmigration/runner/MigrationMetaRow.java
+++ b/src/main/java/io/ebean/dbmigration/runner/MigrationMetaRow.java
@@ -104,11 +104,11 @@ class MigrationMetaRow {
    * Return the SQL insert given the table migration meta data is stored in.
    */
   static String selectSql(String table, String platform) {
-    String sql = "select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from " + table + " order by id";
+    String sql = "select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from " + table;
     if (SQLSERVER.equals(platform)) {
-      return sql + " with (updlock)";
+      return sql + " with (updlock) order by id";
     } else {
-      return sql + " for update";
+      return sql + " order by id for update";
     }
   }
 


### PR DESCRIPTION
order by id must be placed AFTER "with (updlock)" on SQLSERVER