### PR TITLE
Use connection.getSchema() if no schema is explicitly configured

### DIFF
--- a/src/main/java/io/ebean/dbmigration/runner/MigrationTable.java
+++ b/src/main/java/io/ebean/dbmigration/runner/MigrationTable.java
@@ -165,7 +165,7 @@ public class MigrationTable {
     if (metaData.storesUpperCaseIdentifiers()) {
       migTable = migTable.toUpperCase();
     }
-    ResultSet tables = metaData.getTables(catalog, schema, migTable, null);
+    ResultSet tables = metaData.getTables(catalog, (schema != null) ? schema : connection.getSchema(), migTable, null);
     try {
       return tables.next();
     } finally {


### PR DESCRIPTION
This relates to #3 which I'm still running into.

I'm setting the schema via my connection URL (e.g. `jdbc:postgresql://172.28.128.6/postgres?currentSchema=veneer2&user=bla&password=123`) and this seems to work well with ebean otherwise. It would be nice not having to duplicate this information into another config property.
