### PR TITLE
Fix/create pk

### DIFF
--- a/src/main/java/io/ebean/dbmigration/runner/ScriptTransform.java
+++ b/src/main/java/io/ebean/dbmigration/runner/ScriptTransform.java
@@ -9,10 +9,15 @@ import java.util.Map;
 class ScriptTransform {
 
   /**
-   * Transform just ${table} with the table name.
+   * Transform ${table} with the table name and ${schema_prefix} with the schema name + '.'.
    */
-  public static String table(String tableName, String script) {
-    return script.replace("${table}", tableName);
+  public static String schemaTable(String schemaName, String tableName, String script) {
+    if (schemaName == null || schemaName.isEmpty()) {
+    	script = script.replace("${schema_prefix}", "");
+    } else {
+    	script = script.replace("${schema_prefix}", schemaName + ".");   	
+    }
+	  return script.replace("${table}", tableName);
   }
 
   private final Map<String,String> placeholders = new HashMap<>();

--- a/src/main/resources/migration-support/default-create-table.sql
+++ b/src/main/resources/migration-support/default-create-table.sql
@@ -1,4 +1,4 @@
-create table ${catalog_schema}${table} (
+create table ${schema_prefix}${table} (
   id                           integer not null,
   mtype                        varchar(1) not null,
   mstatus                      varchar(10) not null,

--- a/src/main/resources/migration-support/default-create-table.sql
+++ b/src/main/resources/migration-support/default-create-table.sql
@@ -1,4 +1,4 @@
-create table ${table} (
+create table ${catalog_schema}${table} (
   id                           integer not null,
   mtype                        varchar(1) not null,
   mstatus                      varchar(10) not null,

--- a/src/main/resources/migration-support/sqlserver-create-table.sql
+++ b/src/main/resources/migration-support/sqlserver-create-table.sql
@@ -1,4 +1,4 @@
-create table ${table} (
+create table ${schema_prefix}${table} (
   id                           integer not null,
   mtype                        varchar(1) not null,
   mstatus                      varchar(10) not null,


### PR DESCRIPTION
Fixes the commit in PR https://github.com/ebean-orm/ebean-dbmigration/issues/17 that was used instead of https://github.com/ebean-orm/ebean-dbmigration/pull/15

With the current code in ebean-dbmigration version 10.1.5 the private key name (constraint) is wrong in sqlserver-create-table.sql
`constraint pk_${table} primary key (id)`

wrong: pk_schemaPrefix.tableName --> syntax error near "."
correct: pk_tableName