### PR TITLE
FIX: createSchemaIfNeeded for SQLServer

### DIFF
--- a/src/main/java/io/ebean/dbmigration/runner/MigrationSchema.java
+++ b/src/main/java/io/ebean/dbmigration/runner/MigrationSchema.java
@@ -49,9 +49,9 @@ public class MigrationSchema {
   private void createSchemaIfNeeded() throws SQLException {
     if (!schemaExists()) {
       logger.info("Creating Schema: {}", dbSchema);
-      PreparedStatement query = connection.prepareStatement("CREATE SCHEMA " + dbSchema);
+      Statement query = connection.createStatement();
       try {
-        query.execute();
+        query.executeUpdate("CREATE SCHEMA " + dbSchema);
       } finally {
         JdbcClose.close(query);
       }

--- a/src/main/java/io/ebean/dbmigration/util/JdbcClose.java
+++ b/src/main/java/io/ebean/dbmigration/util/JdbcClose.java
@@ -7,6 +7,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  * Utility for closing raw Jdbc resources.
@@ -37,7 +38,7 @@ public class JdbcClose {
     }
   }
 
-  public static void close(PreparedStatement query) {
+  public static void close(Statement query) {
     try {
       query.close();
     } catch (SQLException e) {


### PR DESCRIPTION
This fixes createSchemaIfNeeded for Microsoft SQLServer

What does NOT work:

```java
PreparedStatement query = connection.prepareStatement("CREATE SCHEMA " + dbSchema);
query.execute();
```
```java
Statement query = connection.createStatement();
query.execute("CREATE SCHEMA " + dbSchema);
```
```java
PreparedStatement query = connection.prepareStatement("CREATE SCHEMA " + dbSchema);
query.executeUpdate();
```

all of them will throw `com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near the keyword 'SCHEMA'`