### PR TITLE
FIX: check catalog also. 

### DIFF
--- a/src/main/java/io/ebean/dbmigration/runner/MigrationTable.java
+++ b/src/main/java/io/ebean/dbmigration/runner/MigrationTable.java
@@ -192,8 +192,9 @@ public class MigrationTable {
     if (metaData.storesUpperCaseIdentifiers()) {
       migTable = migTable.toUpperCase();
     }
+    String checkCatalog = (catalog != null) ? catalog : connection.getCatalog();
     String checkSchema = (schema != null) ? schema : connection.getSchema();
-    ResultSet tables = metaData.getTables(catalog, checkSchema, migTable, null);
+    ResultSet tables = metaData.getTables(checkCatalog, checkSchema, migTable, null);
     try {
       return tables.next();
     } finally {


### PR DESCRIPTION
Otherwise on mysql it will find the first db_migration table on the server

Steps to reproduce:
Create multiple databases on Amazon Aurora (mysql compatible)

When multiple ebean instances will connect to different databases only one (the first) will generate the db_migration table, because all other instances will find the other table. 
i.e `metaData.getTables(null, null, "db_migration", null)` will return all "db_migration" tables from all databases (=catalogs) that are accessible from this db-connection