### PR TITLE
Suggested logging, if version string contains illegal characters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.21</version>
+      <version>1.7.25</version>
       <scope>provided</scope>
     </dependency>
 
@@ -52,6 +52,14 @@
       <version>1.1.4</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.25</version>
+      <scope>test</scope>
+    </dependency>
+    
 
     <!--<dependency>-->
       <!--<groupId>microsoft</groupId>-->

--- a/src/main/java/io/ebean/migration/MigrationVersion.java
+++ b/src/main/java/io/ebean/migration/MigrationVersion.java
@@ -2,11 +2,16 @@ package io.ebean.migration;
 
 import java.util.Arrays;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The version of a migration used so that migrations are processed in order.
  */
 public class MigrationVersion implements Comparable<MigrationVersion> {
 
+  private static final Logger logger = LoggerFactory.getLogger(MigrationVersion.class);
+  
   private static final int[] REPEAT_ORDERING = {Integer.MAX_VALUE};
 
   private static final boolean[] REPEAT_UNDERSCORES = {false};
@@ -190,6 +195,8 @@ public class MigrationVersion implements Comparable<MigrationVersion> {
         delimiterPos++;
       } catch (NumberFormatException e) {
         // stop parsing
+        logger.warn("The migrationscript '{}' contains non numeric version part. "
+            + "This may lead to misordered version scripts. NumberFormatException {}", raw, e.getMessage());
         break;
       }
     }

--- a/src/test/java/io/ebean/migration/MigrationVersionTest.java
+++ b/src/test/java/io/ebean/migration/MigrationVersionTest.java
@@ -153,12 +153,16 @@ public class MigrationVersionTest {
     MigrationVersion v2 = MigrationVersion.parse("1.1_1.2_foo");
     MigrationVersion v3 = MigrationVersion.parse("1.1_1.2__foo");
 
+    MigrationVersion v4 = MigrationVersion.parse("1.1_1.2");
+    
     assertThat(v0.compareTo(v1)).isGreaterThan(0);
     assertThat(v1.compareTo(v0)).isLessThan(0);
     assertThat(v1.compareTo(v2)).isEqualTo(0);
 
     assertThat(v0.compareTo(v3)).isLessThan(0);
     assertThat(v3.compareTo(v0)).isGreaterThan(0);
+    
+    assertThat(v4.compareTo(v2)).isEqualTo(0); 
   }
 
   @Test


### PR DESCRIPTION
Hello Rob,
I am not confirm with the current implementation. If there is junk in the version number, the ordering is no longer deterministic (We had the concrete issue that we accidently have named one migration script to "1.2a")

I would suggest that the migration should log a warning if this is the case.

I also think, that the version `1.1.2-SNAPSHOT` > `1.1.2` (which are currently treated as equal)