### PR TITLE
Updated classpath scanner version to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.avaje</groupId>
       <artifactId>avaje-classpath-scanner</artifactId>
-      <version>2.2.4</version>
+      <version>3.1.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
should be the same as in ebean, to avoid convergence errors.