### PR TITLE
multiple migrations that are partially executed may not be inserted in dbmigration-history

### DIFF
--- a/src/main/java/io/ebean/migration/MigrationRunner.java
+++ b/src/main/java/io/ebean/migration/MigrationRunner.java
@@ -144,6 +144,7 @@ public class MigrationRunner {
         break;
       }
       priorVersion = localVersion;
+      connection.commit();
     }
     if (checkStateMode) {
       checkMigrations = table.ran();

--- a/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -109,6 +109,13 @@ public class MigrationTable {
   }
 
   /**
+   * Returns the versions that are already applied.
+   */
+  public Set<String> getVersions() {
+    return migrations.keySet();
+  }
+
+  /**
    * Create the ScriptTransform for placeholder key/value replacement.
    */
   private ScriptTransform createScriptTransform(MigrationConfig config) {

--- a/src/test/java/io/ebean/migration/MigrationTableTest.java
+++ b/src/test/java/io/ebean/migration/MigrationTableTest.java
@@ -1,0 +1,142 @@
+package io.ebean.migration;
+
+import io.ebean.migration.runner.LocalMigrationResource;
+import io.ebean.migration.runner.MigrationTable;
+
+import org.avaje.datasource.DataSourceConfig;
+import org.avaje.datasource.DataSourcePool;
+import org.avaje.datasource.Factory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MigrationTableTest {
+
+  private MigrationConfig config;
+  private DataSourcePool dataSource;
+
+  @BeforeMethod
+  public void setUp() {
+    config = new MigrationConfig();
+    config.setDbUsername("sa");
+    config.setDbPassword("");
+    config.setDbDriver("org.h2.Driver");
+    config.setDbUrl("jdbc:h2:mem:db2");
+
+    DataSourceConfig dataSourceConfig = new DataSourceConfig();
+    dataSourceConfig.setDriver("org.h2.Driver");
+    dataSourceConfig.setUrl("jdbc:h2:mem:db2");
+    dataSourceConfig.setUsername("sa");
+    dataSourceConfig.setPassword("");
+    Factory factory = new Factory();
+    dataSource = factory.createPool("test", dataSourceConfig);
+  }
+
+  @AfterMethod
+  public void shutdown() {
+    dataSource.shutdown(false);
+  }
+
+  @Test
+  public void testMigrationTableBase() throws Exception {
+
+    config.setMigrationPath("dbmig");
+
+    MigrationRunner runner = new MigrationRunner(config);
+    runner.run(dataSource);
+    try (Connection conn = dataSource.getConnection()) {
+      MigrationTable table = new MigrationTable(config, conn, false);
+      table.createIfNeededAndLock();
+      assertThat(table.getVersions()).containsExactly("hello", "1.1", "1.2", "1.2.1", "m2_view");
+      conn.rollback();
+    }
+  }
+
+  @Test
+  public void testMigrationTableRepeatableOk() throws Exception {
+
+    config.setMigrationPath("tabletest1");
+
+    MigrationRunner runner = new MigrationRunner(config);
+    runner.run(dataSource);
+
+    try (Connection conn = dataSource.getConnection()) {
+      MigrationTable table = new MigrationTable(config, conn, false);
+      table.createIfNeededAndLock();
+      assertThat(table.getVersions()).containsExactly("1.1");
+      conn.rollback();
+    }
+
+    config.setMigrationPath("tabletest2");
+
+    runner = new MigrationRunner(config);
+    runner.run(dataSource);
+
+    try (Connection conn = dataSource.getConnection()) {
+      MigrationTable table = new MigrationTable(config, conn, false);
+      table.createIfNeededAndLock();
+      assertThat(table.getVersions()).containsExactly("1.1", "1.2", "m2_view");
+      conn.rollback();
+    }
+  }
+
+  @Test
+  public void testMigrationTableRepeatableFail() throws Exception {
+
+    config.setMigrationPath("tabletest1");
+
+    MigrationRunner runner = new MigrationRunner(config);
+    runner.run(dataSource);
+
+    try (Connection conn = dataSource.getConnection()) {
+      MigrationTable table = new MigrationTable(config, conn, false);
+      table.createIfNeededAndLock();
+      assertThat(table.getVersions()).containsExactly("1.1");
+      conn.rollback();
+    }
+
+    // now execute corrupt migration
+    config.setMigrationPath("tabletest2-err");
+
+    MigrationRunner runner2 = new MigrationRunner(config);
+
+    // so this run will fail, because the "R__" script contains an error
+    assertThatThrownBy(() -> runner2.run(dataSource)).hasMessageContaining("i am corrupt");
+
+    try (Connection conn = dataSource.getConnection()) {
+
+      List<String> m3Content = new ArrayList<>();
+      try (
+          // the next statement will fail, if "1.3__add_m3" is not executed
+          PreparedStatement stmt = conn.prepareStatement("select * from m3");
+          ResultSet result = stmt.executeQuery()) {
+        while (result.next()) {
+          m3Content.add(result.getString(2));
+        }
+      }
+
+      // the next statement will fail, if "1.3__add_m3" is not executed
+      //
+      // BUT: currently, we will fail here. that means, the 1.3 script creates the table
+      // but does not insert the data. (there was not commit) This might be also a bug in H2
+      assertThat(m3Content).contains("text with ; sign");
+
+      // we expect, that 1.1 and 1.2 is executed (but not the R__ script)
+      MigrationTable table = new MigrationTable(config, conn, false);
+      table.createIfNeededAndLock();
+      assertThat(table.getVersions()).containsExactly("1.1", "1.2");
+      conn.rollback();
+    }
+  }
+}

--- a/src/test/resources/tabletest1/1.1__initial.sql
+++ b/src/test/resources/tabletest1/1.1__initial.sql
@@ -1,0 +1,3 @@
+create table m1 (id integer, acol varchar(20));
+
+create table m2 (id integer, acol varchar(20), bcol timestamp);

--- a/src/test/resources/tabletest2-err/1.1__initial.sql
+++ b/src/test/resources/tabletest2-err/1.1__initial.sql
@@ -1,0 +1,3 @@
+create table m1 (id integer, acol varchar(20));
+
+create table m2 (id integer, acol varchar(20), bcol timestamp);

--- a/src/test/resources/tabletest2-err/1.2__add_m3.sql
+++ b/src/test/resources/tabletest2-err/1.2__add_m3.sql
@@ -1,0 +1,5 @@
+create table m3 (id integer, acol varchar(20), bcol timestamp);
+
+alter table m1 add column addcol varchar(10);
+
+insert into m3 (id, acol) VALUES (1, 'text with ; sign'); -- plus some comment

--- a/src/test/resources/tabletest2-err/R__m2_view.sql
+++ b/src/test/resources/tabletest2-err/R__m2_view.sql
@@ -1,0 +1,1 @@
+i am corrupt;

--- a/src/test/resources/tabletest2/1.1__initial.sql
+++ b/src/test/resources/tabletest2/1.1__initial.sql
@@ -1,0 +1,3 @@
+create table m1 (id integer, acol varchar(20));
+
+create table m2 (id integer, acol varchar(20), bcol timestamp);

--- a/src/test/resources/tabletest2/1.2__add_m3.sql
+++ b/src/test/resources/tabletest2/1.2__add_m3.sql
@@ -1,0 +1,5 @@
+create table m3 (id integer, acol varchar(20), bcol timestamp);
+
+alter table m1 add column addcol varchar(10);
+
+insert into m3 (id, acol) VALUES (1, 'text with ; sign'); -- plus some comment

--- a/src/test/resources/tabletest2/R__m2_view.sql
+++ b/src/test/resources/tabletest2/R__m2_view.sql
@@ -1,0 +1,1 @@
+create or replace view m2_vw as select id, acol from m2;


### PR DESCRIPTION
We deployed an application, that has an additional migration script and a repeatable script (which contained an error).

what happened:
- the additional script was executed
- the repeatable script was executed and failed
- nothing was inserted in dbmigration history

unfortunately, the additional script was partially commited in the database, so fixing the R script did not help, as with the next deployment, the additinal script was executed again and failed, because the the tables already exist.

A possible fix could be to invoke a commit after each script.

