### PR TITLE
Adds a message to log, when running JDBC migration.

### DIFF
--- a/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -29,7 +29,7 @@ import static io.ebean.migration.MigrationVersion.BOOTINIT_TYPE;
  */
 public class MigrationTable {
 
-  private static final Logger logger = LoggerFactory.getLogger(MigrationTable.class);
+  private static final Logger logger = LoggerFactory.getLogger("io.ebean.DDL");
 
   private final Connection connection;
   private final boolean checkState;

--- a/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -1,5 +1,6 @@
 package io.ebean.migration.runner;
 
+import io.ebean.migration.JdbcMigration;
 import io.ebean.migration.MigrationConfig;
 import io.ebean.migration.MigrationException;
 import io.ebean.migration.MigrationVersion;
@@ -336,7 +337,9 @@ public class MigrationTable {
       MigrationScriptRunner run = new MigrationScriptRunner(connection);
       run.runScript(false, script, "run migration version: " + local.getVersion());
     } else {
-      ((LocalJdbcMigrationResource) local).getMigration().migrate(connection);
+      JdbcMigration migration = ((LocalJdbcMigrationResource) local).getMigration();
+      logger.info("Executing jdbc migration version: {} - {}", local.getVersion(), migration);
+      migration.migrate(connection);
     }
     long exeMillis = System.currentTimeMillis() - start;
 

--- a/src/test/java/dbmig/V1_2_1__test.java
+++ b/src/test/java/dbmig/V1_2_1__test.java
@@ -26,4 +26,8 @@ public class V1_2_1__test implements JdbcMigration, ConfigurationAware{
     System.out.println("Executing migration on " + connection);
   }
 
+  @Override
+  public String toString() {
+    return "Dummy jdbc migration";
+  }
 }


### PR DESCRIPTION
When a JDBC migration is executed, this should also be logged.


Output is now
```log
[main] INFO io.ebean.DDL - Executing run migration version: I__hello - 0 statements
[main] INFO io.ebean.DDL - Executing run migration version: 1.1__initial - 2 statements
[main] INFO io.ebean.DDL - Executing run migration version: 1.2__add_m3 - 3 statements
[main] INFO io.ebean.migration.runner.MigrationTable - Executing jdbc migration version: 1_2_1__test - Dummy jdbc migration
```