### PR TITLE
DdlParser with string literal containing both semicolon and newline

### DIFF
--- a/src/test/java/io/ebean/migration/ddl/DdlParserTest.java
+++ b/src/test/java/io/ebean/migration/ddl/DdlParserTest.java
@@ -87,6 +87,13 @@ public class DdlParserTest {
   }
 
   @Test
+  public void parse_semiInContent_withLinefeedInContent() {
+
+    List<String> stmts = parser.parse(new StringReader("insert ('one;\n');"));
+    assertThat(stmts).containsExactly("insert ('one;\n');");
+  }
+
+  @Test
   public void parse_noTailingSemi() {
 
     List<String> stmts = parser.parse(new StringReader("one"));


### PR DESCRIPTION
This is just the test case, not a solution.
