### PR TITLE
Ignore inner classes in JdbcMigrations

### DIFF
--- a/src/main/java/io/ebean/migration/runner/LocalMigrationResources.java
+++ b/src/main/java/io/ebean/migration/runner/LocalMigrationResources.java
@@ -112,7 +112,7 @@ public class LocalMigrationResources {
     @Override
     public boolean isMatch(String name) {
       return name.endsWith(migrationConfig.getApplySuffix())
-          || migrationConfig.getJdbcMigrationFactory() != null && name.endsWith(".class");
+          || migrationConfig.getJdbcMigrationFactory() != null && name.endsWith(".class") && !name.contains("$");
     }
   }
 }

--- a/src/test/java/dbmig/V1_2_1__test.java
+++ b/src/test/java/dbmig/V1_2_1__test.java
@@ -16,6 +16,10 @@ public class V1_2_1__test implements JdbcMigration, ConfigurationAware{
 
   private MigrationConfig config;
 
+  public static class MyDto {
+    String id;
+  }
+  
   @Override
   public void setMigrationConfig(MigrationConfig config) {
     this.config = config;


### PR DESCRIPTION
Hi Rob,

we want to use inner classes in our JdbcMigrations. Unfortunately, the current implementation tries to cast inner classes to JdbcMigration, which of course fails. I excluded all paths which contain '$' and enhanced the test entity accordingly. Without the modification to LocalMigrationResources, the MigrationTableTest fails.

Best regards,
Manuel