### PR TITLE
ENH: support for specifying a min-version to enforce certain migration paths

### DIFF
--- a/src/main/java/io/ebean/migration/MigrationConfig.java
+++ b/src/main/java/io/ebean/migration/MigrationConfig.java
@@ -57,6 +57,20 @@ public class MigrationConfig {
   private Set<String> patchResetChecksumOn;
 
   /**
+   * The minimum version, that must be in the dbmigration table. If the current maxVersion
+   * in the migration table is greater than this version, the MigrationRunner will fail
+   * with a {@link MigrationException} and an optional {@link #minVersionFailMessage}
+   * to enforce certain migration paths.
+   */
+  private String minVersion;
+
+  /**
+   * The (customizable) fail message, if minVersion is not in database.
+   * (e.g. "To perform an upgrade, you must install APP XY first")
+   */
+  private String minVersionFailMessage;
+
+  /**
    * Return the name of the migration table.
    */
   public String getMetaTable() {
@@ -417,6 +431,34 @@ public class MigrationConfig {
   }
 
   /**
+   * Returns the minVersion.
+   */
+  public String getMinVersion() {
+    return minVersion;
+  }
+
+  /**
+   * Set the minVersion.
+   */
+  public void setMinVersion(String minVersion) {
+    this.minVersion = minVersion;
+  }
+
+  /**
+   * Sets the optional minVersionFailMessage.
+   */
+  public String getMinVersionFailMessage() {
+    return minVersionFailMessage;
+  }
+
+  /**
+   * @param minVersionFailMessage the minVersionFailMessage to set
+   */
+  public void setMinVersionFailMessage(String minVersionFailMessage) {
+    this.minVersionFailMessage = minVersionFailMessage;
+  }
+
+  /**
    * Load configuration from standard properties.
    */
   public void load(Properties props) {
@@ -446,6 +488,8 @@ public class MigrationConfig {
     migrationPath = props.getProperty("dbmigration.migrationPath", migrationPath);
     migrationInitPath = props.getProperty("dbmigration.migrationInitPath", migrationInitPath);
     runPlaceholders = props.getProperty("dbmigration.placeholders", runPlaceholders);
+    minVersion = props.getProperty("dbmigration.minVersion", minVersion);
+    minVersionFailMessage = props.getProperty("dbmigration.minVersionFailMessage", minVersionFailMessage);
 
     String patchInsertOn = props.getProperty("dbmigration.patchInsertOn");
     if (patchInsertOn != null) {

--- a/src/main/java/io/ebean/migration/MigrationVersion.java
+++ b/src/main/java/io/ebean/migration/MigrationVersion.java
@@ -18,7 +18,7 @@ public class MigrationVersion implements Comparable<MigrationVersion> {
 
   private static final String REPEAT_TYPE = "R";
 
-  private static final String VERSION_TYPE = "V";
+  public static final String VERSION_TYPE = "V";
 
   private static final int[] REPEAT_ORDERING_MIN = {Integer.MIN_VALUE};
 

--- a/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import static io.ebean.migration.MigrationVersion.BOOTINIT_TYPE;
+import static io.ebean.migration.MigrationVersion.VERSION_TYPE;
 
 /**
  * Manages the migration table.
@@ -57,6 +58,10 @@ public class MigrationTable {
   private final Set<String> patchResetChecksumVersions;
   private final boolean allowErrorInRepeatable;
 
+  private final MigrationVersion minVersion;
+  private final String minVersionFailMessage;
+
+  private MigrationVersion currentVersion;
   private MigrationMetaRow lastMigration;
   private LocalMigrationResource priorVersion;
 
@@ -80,6 +85,9 @@ public class MigrationTable {
     this.allowErrorInRepeatable = config.isAllowErrorInRepeatable();
     this.patchResetChecksumVersions = config.getPatchResetChecksumOn();
     this.patchInsertVersions = config.getPatchInsertOn();
+    this.minVersion = config.getMinVersion() == null || config.getMinVersion().isEmpty() ? null
+        : MigrationVersion.parse(config.getMinVersion());
+    this.minVersionFailMessage = config.getMinVersionFailMessage();
     this.skipChecksum = config.isSkipChecksum();
     this.schema = config.getDbSchema();
     this.table = config.getMetaTable();
@@ -427,9 +435,17 @@ public class MigrationTable {
     if (metaRow.getVersion() == null) {
       throw new IllegalStateException("No runVersion in db migration table row? " + metaRow);
     }
+
     migrations.put(key, metaRow);
-    if (BOOTINIT_TYPE.equals(metaRow.getType())) {
-      dbInitVersion = MigrationVersion.parse(metaRow.getVersion());
+    if (VERSION_TYPE.equals(metaRow.getType())
+        || BOOTINIT_TYPE.equals(metaRow.getType())) {
+      MigrationVersion rowVersion = MigrationVersion.parse(metaRow.getVersion());
+      if (currentVersion == null || rowVersion.compareTo(currentVersion) > 0) {
+        currentVersion = rowVersion;
+      }
+      if (BOOTINIT_TYPE.equals(metaRow.getType())) {
+        dbInitVersion = rowVersion;
+      }
     }
   }
 
@@ -446,6 +462,16 @@ public class MigrationTable {
    * @return the migrations that have been run (collected if checkstate is true).
    */
   public List<LocalMigrationResource> runAll(List<LocalMigrationResource> localVersions) throws SQLException {
+
+    if (currentVersion != null && minVersion!= null && currentVersion.compareTo(minVersion) < 0) {
+      StringBuilder sb = new StringBuilder();
+      if (minVersionFailMessage != null && !minVersionFailMessage.isEmpty()) {
+        sb.append(minVersionFailMessage).append(' ');
+      }
+      sb.append("MigrationVersion mismatch: v").append(currentVersion).append(" < v").append(minVersion);
+
+      throw new MigrationException(sb.toString());
+    }
     for (LocalMigrationResource localVersion : localVersions) {
       if (!localVersion.isRepeatable() && dbInitVersion != null && dbInitVersion.compareTo(localVersion.getVersion()) >= 0) {
         logger.debug("migration skipped by dbInitVersion {}", dbInitVersion);


### PR DESCRIPTION
This feature supports a minversion in MigrationConfig to enforce certain migration paths.

This allows you, to delete older migration scripts/java-migration-routines if you want to drop support for these (e.g. for scripts based on user stored procedures) and enforce a certain path in the same time.

Example. Put this in your 2.12 app:
```
dbmigration.minVersion=2.9
dbmigration.minVersionFailMessage=This app requires a minimum version of 2.9, 2.10 or 2.11 installed first.
```
