### PR TITLE
Support Postgres "create index concurrently"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,16 @@ mvn install:install-file -Dfile=/some/path/to/ojdbc7.jar -DgroupId=oracle \
     </dependency>
 
     <dependency>
-      <groupId>org.avaje</groupId>
-      <artifactId>avaje-datasource</artifactId>
-      <version>1.1.4</version>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-datasource</artifactId>
+      <version>4.7.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/io/ebean/migration/ddl/DdlAutoCommit.java
+++ b/src/main/java/io/ebean/migration/ddl/DdlAutoCommit.java
@@ -1,0 +1,25 @@
+package io.ebean.migration.ddl;
+
+/**
+ * Detect non transactional SQL statements that must run after normal
+ * sql statements with connection set to auto commit true.
+ */
+public interface DdlAutoCommit {
+
+  DdlAutoCommit NONE = new NoAutoCommit();
+
+  DdlAutoCommit POSTGRES = new PostgresAutoCommit();
+
+  /**
+   * Return the implementation for the given platform.
+   */
+  static DdlAutoCommit forPlatform(String name) {
+    return name.equalsIgnoreCase("postgres") ? POSTGRES : NONE;
+  }
+
+  /**
+   * Return false if the SQL is non transactional and should run with auto commit.
+   */
+  boolean transactional(String sql);
+
+}

--- a/src/main/java/io/ebean/migration/ddl/NoAutoCommit.java
+++ b/src/main/java/io/ebean/migration/ddl/NoAutoCommit.java
@@ -1,0 +1,12 @@
+package io.ebean.migration.ddl;
+
+/**
+ * By default no statements require auto commit.
+ */
+public class NoAutoCommit implements DdlAutoCommit {
+
+  @Override
+  public boolean transactional(String sql) {
+    return true;
+  }
+}

--- a/src/main/java/io/ebean/migration/ddl/PostgresAutoCommit.java
+++ b/src/main/java/io/ebean/migration/ddl/PostgresAutoCommit.java
@@ -1,0 +1,16 @@
+package io.ebean.migration.ddl;
+
+import java.util.regex.Pattern;
+
+/**
+ * Postgres requires create/drop index concurrently to run with auto commit true.
+ */
+public class PostgresAutoCommit implements DdlAutoCommit {
+
+  private static final Pattern IX_CONCURRENTLY = Pattern.compile(Pattern.quote(" index concurrently "), Pattern.CASE_INSENSITIVE);
+
+  @Override
+  public boolean transactional(String sql) {
+    return !IX_CONCURRENTLY.matcher(sql).find();
+  }
+}

--- a/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
+++ b/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
@@ -1,5 +1,7 @@
 package io.ebean.migration.runner;
 
+import io.ebean.migration.ddl.DdlAutoCommit;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -19,6 +21,13 @@ public class MigrationPlatform {
    * Standard row locking for db migration table.
    */
   String forUpdateSuffix = " order by id for update";
+
+  /**
+   * Return the DdlAutoCommit to use for this platform.
+   */
+  DdlAutoCommit ddlAutoCommit() {
+    return DdlAutoCommit.NONE;
+  }
 
   /**
    * Lock the migration table. The base implementation uses row locking but lock table would be preferred when available.
@@ -69,6 +78,11 @@ public class MigrationPlatform {
   }
 
   public static class Postgres extends MigrationPlatform {
+
+    @Override
+    DdlAutoCommit ddlAutoCommit() {
+      return DdlAutoCommit.POSTGRES;
+    }
 
     @Override
     void lockMigrationTable(String sqlTable, Connection connection) throws SQLException {

--- a/src/test/java/io/ebean/migration/MigrationRunnerTest.java
+++ b/src/test/java/io/ebean/migration/MigrationRunnerTest.java
@@ -1,9 +1,9 @@
 package io.ebean.migration;
 
 import io.ebean.migration.runner.LocalMigrationResource;
-import org.avaje.datasource.DataSourceConfig;
-import org.avaje.datasource.DataSourcePool;
-import org.avaje.datasource.Factory;
+import io.ebean.datasource.DataSourceConfig;
+import io.ebean.datasource.DataSourcePool;
+import io.ebean.datasource.DataSourceFactory;
 import org.testng.annotations.Test;
 
 import java.sql.Connection;
@@ -72,8 +72,7 @@ public class MigrationRunnerTest {
     dataSourceConfig.setUsername("sa");
     dataSourceConfig.setPassword("");
 
-    Factory factory = new Factory();
-    DataSourcePool dataSource = factory.createPool("test", dataSourceConfig);
+    DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
 
     MigrationConfig config = createMigrationConfig();
     config.setMigrationPath("dbmig");
@@ -118,8 +117,7 @@ public class MigrationRunnerTest {
     dataSourceConfig.setUsername("sa");
     dataSourceConfig.setPassword("");
 
-    Factory factory = new Factory();
-    DataSourcePool dataSource = factory.createPool("test", dataSourceConfig);
+    DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
 
     MigrationConfig config = createMigrationConfig();
     config.setDbUrl("jdbc:h2:mem:testsDbInit");
@@ -142,8 +140,7 @@ public class MigrationRunnerTest {
     dataSourceConfig.setUsername("sa");
     dataSourceConfig.setPassword("");
 
-    Factory factory = new Factory();
-    DataSourcePool dataSource = factory.createPool("test", dataSourceConfig);
+    DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
 
     MigrationConfig config = createMigrationConfig();
     config.setMigrationPath("dbmig");
@@ -179,8 +176,7 @@ public class MigrationRunnerTest {
     dataSourceConfig.setUsername("sa");
     dataSourceConfig.setPassword("");
 
-    Factory factory = new Factory();
-    DataSourcePool dataSource = factory.createPool("test", dataSourceConfig);
+    DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
 
     // init
     MigrationConfig config = createMigrationConfig();

--- a/src/test/java/io/ebean/migration/MigrationTableTest.java
+++ b/src/test/java/io/ebean/migration/MigrationTableTest.java
@@ -2,9 +2,9 @@ package io.ebean.migration;
 
 import io.ebean.migration.runner.MigrationPlatform;
 import io.ebean.migration.runner.MigrationTable;
-import org.avaje.datasource.DataSourceConfig;
-import org.avaje.datasource.DataSourcePool;
-import org.avaje.datasource.Factory;
+import io.ebean.datasource.DataSourceConfig;
+import io.ebean.datasource.DataSourcePool;
+import io.ebean.datasource.DataSourceFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -36,8 +36,7 @@ public class MigrationTableTest {
     dataSourceConfig.setUrl("jdbc:h2:mem:db2");
     dataSourceConfig.setUsername("sa");
     dataSourceConfig.setPassword("");
-    Factory factory = new Factory();
-    dataSource = factory.createPool("test", dataSourceConfig);
+    dataSource = DataSourceFactory.create("test", dataSourceConfig);
   }
 
   @AfterMethod
@@ -53,8 +52,8 @@ public class MigrationTableTest {
     MigrationRunner runner = new MigrationRunner(config);
     runner.run(dataSource);
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false);
-      table.createIfNeededAndLock(platform);
+      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      table.createIfNeededAndLock();
       assertThat(table.getVersions()).containsExactly("hello", "1.1", "1.2", "1.2.1", "m2_view");
 
       List<String> rawVersions = new ArrayList<>();
@@ -79,8 +78,8 @@ public class MigrationTableTest {
     runner.run(dataSource);
 
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false);
-      table.createIfNeededAndLock(platform);
+      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      table.createIfNeededAndLock();
       assertThat(table.getVersions()).containsExactly("1.1");
       conn.rollback();
     }
@@ -91,8 +90,8 @@ public class MigrationTableTest {
     runner.run(dataSource);
 
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false);
-      table.createIfNeededAndLock(platform);
+      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      table.createIfNeededAndLock();
       assertThat(table.getVersions()).containsExactly("1.1", "1.2", "m2_view");
       conn.rollback();
     }
@@ -108,8 +107,8 @@ public class MigrationTableTest {
     runner.run(dataSource);
 
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false);
-      table.createIfNeededAndLock(platform);
+      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      table.createIfNeededAndLock();
       assertThat(table.getVersions()).containsExactly("1.1");
       conn.rollback();
     }
@@ -140,8 +139,8 @@ public class MigrationTableTest {
       assertThat(m3Content).contains("text with ; sign");
 
       // we expect, that 1.1 and 1.2 is executed (but not the R__ script)
-      MigrationTable table = new MigrationTable(config, conn, false);
-      table.createIfNeededAndLock(platform);
+      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      table.createIfNeededAndLock();
       assertThat(table.getVersions()).containsExactly("1.1", "1.2");
       conn.rollback();
     }

--- a/src/test/java/io/ebean/migration/ddl/DdlAutoCommitTest.java
+++ b/src/test/java/io/ebean/migration/ddl/DdlAutoCommitTest.java
@@ -1,0 +1,22 @@
+package io.ebean.migration.ddl;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DdlAutoCommitTest {
+
+  @Test
+  public void testForPlatform_postgres() {
+    assertThat(DdlAutoCommit.forPlatform("postgres")).isInstanceOf(PostgresAutoCommit.class);
+    assertThat(DdlAutoCommit.forPlatform("POSTGRES")).isInstanceOf(PostgresAutoCommit.class);
+    assertThat(DdlAutoCommit.forPlatform("Postgres")).isInstanceOf(PostgresAutoCommit.class);
+  }
+
+  @Test
+  public void testForPlatform_others() {
+    assertThat(DdlAutoCommit.forPlatform("other")).isInstanceOf(NoAutoCommit.class);
+    assertThat(DdlAutoCommit.forPlatform("mysql")).isInstanceOf(NoAutoCommit.class);
+    assertThat(DdlAutoCommit.forPlatform("oracle")).isInstanceOf(NoAutoCommit.class);
+  }
+}

--- a/src/test/java/io/ebean/migration/runner/MigrationPlatformTest.java
+++ b/src/test/java/io/ebean/migration/runner/MigrationPlatformTest.java
@@ -1,0 +1,29 @@
+package io.ebean.migration.runner;
+
+import io.ebean.migration.ddl.DdlAutoCommit;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class MigrationPlatformTest {
+
+  private final MigrationPlatform.Postgres platform = new MigrationPlatform.Postgres();
+
+  final DdlAutoCommit pg = platform.ddlAutoCommit();
+
+  @Test
+  public void transaction_false() {
+    assertFalse(pg.transactional("create index concurrently foo"));
+    assertFalse(pg.transactional("drop index concurrently foo"));
+    assertFalse(pg.transactional("CREATE INDEX CONCURRENTLY foo"));
+    assertFalse(pg.transactional("DROP INDEX CONCURRENTLY foo"));
+  }
+
+  @Test
+  public void transaction_true() {
+    assertTrue(pg.transactional("create index foo"));
+    assertTrue(pg.transactional("drop index foo"));
+    assertTrue(pg.transactional("CREATE INDEX foo"));
+    assertTrue(pg.transactional("DROP INDEX foo"));
+  }
+}

--- a/src/test/java/io/ebean/migration/runner/MigrationTableTest.java
+++ b/src/test/java/io/ebean/migration/runner/MigrationTableTest.java
@@ -17,7 +17,7 @@ public class MigrationTableTest {
     MigrationConfig config = new MigrationConfig();
     config.setDbSchema("foo");
 
-    MigrationTable mt = new MigrationTable(config, null, false);
+    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
     String tableSql = mt.createTableDdl();
 
     assertThat(tableSql).contains("create table foo.db_migration ");
@@ -31,7 +31,7 @@ public class MigrationTableTest {
     config.setDbSchema("bar");
     config.setPlatformName(DbPlatformNames.SQLSERVER);
 
-    MigrationTable mt = new MigrationTable(config, null, false);
+    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
     String tableSql = mt.createTableDdl();
 
     assertThat(tableSql).contains("datetime2 ");
@@ -47,7 +47,7 @@ public class MigrationTableTest {
     LocalMigrationResource local = local("R__hello");
     MigrationMetaRow existing = new MigrationMetaRow(12, "R", "", "comment", 42, null, null, 0);
 
-    MigrationTable mt = new MigrationTable(config, null, false);
+    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
     // checksum different - no skip
     assertFalse(mt.skipMigration(100, local, existing));
     // checksum same - skip
@@ -60,7 +60,7 @@ public class MigrationTableTest {
     MigrationConfig config = new MigrationConfig();
     config.setSkipChecksum(true);
 
-    MigrationTable mt = new MigrationTable(config, null, false);
+    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
 
     // skip regardless of checksum difference
     LocalMigrationResource local = local("R__hello");

--- a/src/test/resources/dbmig_postgres_concurrently0/2.1__m5.sql
+++ b/src/test/resources/dbmig_postgres_concurrently0/2.1__m5.sql
@@ -1,0 +1,3 @@
+create table m5 (id integer, acol varchar(20), bcol timestamp);
+
+create index concurrently ix_m5_acol on m5 (acol);

--- a/src/test/resources/dbmig_postgres_concurrently1/2.2__m6.sql
+++ b/src/test/resources/dbmig_postgres_concurrently1/2.2__m6.sql
@@ -1,0 +1,5 @@
+create table m6 (id integer, acol varchar(20), bcol timestamp);
+
+drop index concurrently ix_m5_acol;
+create index concurrently ix_m5_acol2 on m5 (acol,id);
+create index concurrently ix_m6_acol2 on m6 (bcol); -- junk


### PR DESCRIPTION
- This requires the statement to run with auto commit true
- These statements are separated from the normal migration statements and run AFTER the normal migration commit, as such they are no longer "Atomic" in that the migration can complete and commit but the following non-transactional create index concurrently can fail (and then should likely be re-created manually)