### PR TITLE
Also check for init migrations before skipping the migration run

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/MigrationRunner.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/MigrationRunner.java
@@ -94,7 +94,7 @@ public class MigrationRunner {
    */
   protected void run(Connection connection, boolean checkStateMode) {
     LocalMigrationResources resources = new LocalMigrationResources(migrationConfig);
-    if (!resources.readResources()) {
+    if (!resources.readResources() && !resources.readInitResources()) {
       log.debug("no migrations to check");
       return;
     }

--- a/ebean-migration/src/test/resources/dbmig6_init/1.0__m4.sql
+++ b/ebean-migration/src/test/resources/dbmig6_init/1.0__m4.sql
@@ -1,0 +1,9 @@
+create table m1 (id integer, acol varchar(20), addcol varchar(10));
+
+create table m2 (id integer, acol varchar(20), bcol timestamp);
+
+create  table m3 (id integer, acol varchar(20), bcol timestamp);
+
+create table m4 (id integer, acol varchar(20), bcol timestamp);
+
+insert into m3 (id, acol) VALUES (1, 'text with ; sign'); -- plus some comment


### PR DESCRIPTION
This change fixes a problem where when you only have init migrations and no "regular" migration scripts yet (e.g. when starting a new project or adding support for a new database system), the migration was skipped, because there was no check for presence of init migrations.
The added test does verify that by also checking the scripts run (which I also added to the existing init-test).