### PR TITLE
DB2: MigrationTable is not found, when schema contains underscore

### DIFF
--- a/ebean-migration/pom.xml
+++ b/ebean-migration/pom.xml
@@ -92,6 +92,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <version>11.5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <!--
 mvn install:install-file -Dfile=/some/path/to/ojdbc7.jar -DgroupId=oracle \
           -DartifactId=oracle-jdbc -Dversion=7.0 -Dpackaging=jar

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -229,11 +229,15 @@ public class MigrationTable {
     if (metaData.storesUpperCaseIdentifiers()) {
       migTable = migTable.toUpperCase();
     }
-    String checkCatalog = (catalog != null) ? catalog : connection.getCatalog();
-    String checkSchema = (schema != null) ? schema : connection.getSchema();
+    String checkCatalog = (catalog != null) ? catalog : trim(connection.getCatalog());
+    String checkSchema = (schema != null) ? schema : trim(connection.getSchema());
     try (ResultSet tables = metaData.getTables(checkCatalog, checkSchema, migTable, null)) {
       return tables.next();
     }
+  }
+
+  private String trim(String s) {
+    return s == null ? null : s.trim();
   }
 
   /**

--- a/ebean-migration/src/test/java/io/ebean/migration/MigrationTableTestDb2.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/MigrationTableTestDb2.java
@@ -1,0 +1,62 @@
+package io.ebean.migration;
+
+import io.ebean.migration.runner.MigrationPlatform;
+import io.ebean.migration.runner.MigrationTable;
+import io.ebean.datasource.DataSourceConfig;
+import io.ebean.datasource.DataSourcePool;
+import io.ebean.datasource.DataSourceFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MigrationTableTestDb2 {
+
+  private static MigrationConfig config;
+  private static DataSourcePool dataSource;
+  private MigrationPlatform platform = new MigrationPlatform();
+
+  @BeforeEach
+  public void setUp() {
+    config = new MigrationConfig();
+    config.setDbUsername("unit");
+    config.setDbPassword("test");
+    config.setMetaTable("bla");
+    config.setDbUrl("jdbc:db2://localhost:50000/unit:currentSchema=Sch_2;"); // Sch2 will work
+
+    DataSourceConfig dataSourceConfig = new DataSourceConfig();
+    dataSourceConfig.setUrl("jdbc:db2://localhost:50000/unit:currentSchema=Sch_2;");
+    dataSourceConfig.setUsername("unit");
+    dataSourceConfig.setPassword("test");
+    dataSource = DataSourceFactory.create("test", dataSourceConfig);
+  }
+
+  @AfterEach
+  public void shutdown() {
+    dataSource.shutdown();
+  }
+
+  @Disabled // run test manually
+  @Test
+  public void testMigrationTableBase() throws Exception {
+
+    config.setMigrationPath("dbmig");
+
+    try (Connection conn = dataSource.getConnection()) {
+      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      table.createIfNeededAndLock();
+      table.createIfNeededAndLock();
+      conn.commit();
+    }
+  }
+}


### PR DESCRIPTION
We have found a weird issue, that `tableExists()` will not find an existing table, if the `currentSchema` URL parameter is less than 8 characters AND contains an underscore (Really?)

We tracked down the issue, and see, that `connection.getSchema()` always returns a string with minimum length of 8 chars. 
For `jdbc:db2://localhost:50000/unit:currentSchema=Sch_2;` it will return `"Sch_2   "`
This string is passed into `getTables` which is effectively translated to `CALL SYSIBM.SQLTABLES(?,?,?,?,?)` by the JDBC driver

While `CALL SYSIBM.SQLTABLES(null,'Sch1    ', null,null,null)` will return all tables in Schema `Sch1` (does not depend on spaces)
The `CALL SYSIBM.SQLTABLES(null,'Sch_1   ', null,null,null)` will return nothing.
While the `CALL SYSIBM.SQLTABLES(null,'Sch_1', null,null,null)` will return all tables of schema `Sch_1`

There are similar issues with underscore like this: https://www.ibm.com/support/pages/apar/PK48336

So as workaround, **do not use underscores in schema names.**
We recommend to use max 8 chars, uppercase and no special chars in schema/db-name.

@rbygrave this is a problem with the DB2 driver/platform which can be easily avoided. Feel free to merge or decline this PR. 
Cheers
Roland
