### PR TITLE
Switching to logical lock for DB2

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/DbNameUtil.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/DbNameUtil.java
@@ -79,6 +79,7 @@ class DbNameUtil implements DbPlatformNames {
         return new MigrationPlatform.MySql();
       case ORACLE:
       case H2:
+      case DB2:
         return new MigrationPlatform.LogicalLock();
       case POSTGRES:
         return new MigrationPlatform.Postgres();

--- a/ebean-migration/src/test/java/io/ebean/migration/MigrationTableAsyncTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/MigrationTableAsyncTest.java
@@ -44,7 +44,12 @@ public class MigrationTableAsyncTest {
   @Disabled
   @Test
   public void testDb2() throws Exception {
-    // Works
+    // Note: Holding any lock during "reorg table" does not work
+    // (checked row lock and 'lock table x in exclusive mode')
+    // as soon as reorg table is executed, all locks held by the current
+    // connection are dropped
+    // See comment in 1.1__initial.sql
+    
     Db2Container container = Db2Container.builder("latest")
       .port(50055)
       .containerName("mig_async_db2")

--- a/ebean-migration/src/test/resources/dbmig/1.1__initial.sql
+++ b/ebean-migration/src/test/resources/dbmig/1.1__initial.sql
@@ -1,3 +1,5 @@
 create table m1 (id integer, acol varchar(20));
-
+-- Check with DB2:
+-- call sysproc.admin_cmd('reorg table m1');
 create table m2 (id integer, acol varchar(20), bcol timestamp);
+

--- a/ebean-migration/src/test/resources/dbmig4/1.1__initial.sql
+++ b/ebean-migration/src/test/resources/dbmig4/1.1__initial.sql
@@ -1,3 +1,5 @@
 create table m1 (id integer, acol varchar(20));
-
+-- Check with DB2:
+-- call sysproc.admin_cmd('reorg table m1');
 create table m2 (id integer, acol varchar(20), bcol timestamp);
+

--- a/ebean-migration/src/test/resources/dbmig5_base/1.1__initial.sql
+++ b/ebean-migration/src/test/resources/dbmig5_base/1.1__initial.sql
@@ -1,3 +1,5 @@
 create table m1 (id integer, acol varchar(20));
-
+-- Check with DB2:
+-- call sysproc.admin_cmd('reorg table m1');
 create table m2 (id integer, acol varchar(20), bcol timestamp);
+


### PR DESCRIPTION
For DB2, we require the "logical lock" which does not rely on DB-locks that are bound to the connection.

The default locking works as long as no `reorg table` is involved in the DB2 migration scripts.
It seems, that the reorg utility will release all locks.

The [documentation ](https://www.ibm.com/docs/en/db2/11.5?topic=commands-reorg-table) also mentions

> Be sure to complete all database operations and release all locks before you start the REORG TABLE utility.

We've tested alternatives, like "lock table with exclusive mode", but that do not work either.
So we switched to logical lock, which isn't the best choice in performance/db-load, but works

@rbygrave do you think, you can provide a new ebean-migration version next week or so?

cheers
Roland
