### PR TITLE
Make LocalDdlMigrationResource and LocalJdbcMigrationResource internal (not public)

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/runner/Checksum.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/Checksum.java
@@ -14,9 +14,9 @@ class Checksum {
   /**
    * Returns the checksum of the string content.
    */
-  static int calculate(String str) {
+  static int calculate(String content) {
     final CRC32 crc32 = new CRC32();
-    BufferedReader bufferedReader = new BufferedReader(new StringReader(str));
+    BufferedReader bufferedReader = new BufferedReader(new StringReader(content));
     try {
       String line;
       while ((line = bufferedReader.readLine()) != null) {

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/LocalDdlMigrationResource.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/LocalDdlMigrationResource.java
@@ -9,14 +9,14 @@ import java.util.List;
 /**
  * A DB migration resource (DDL script with version).
  */
-public class LocalDdlMigrationResource extends LocalMigrationResource {
+final class LocalDdlMigrationResource extends LocalMigrationResource {
 
   private final Resource resource;
 
   /**
    * Construct with version and resource.
    */
-  public LocalDdlMigrationResource(MigrationVersion version, String location, Resource resource) {
+  LocalDdlMigrationResource(MigrationVersion version, String location, Resource resource) {
     super(version, location);
     this.resource = resource;
   }
@@ -24,17 +24,10 @@ public class LocalDdlMigrationResource extends LocalMigrationResource {
   /**
    * Return the content for the migration apply ddl script.
    */
+  @Override
   public String content() {
     try {
       return resource.loadAsString(StandardCharsets.UTF_8);
-    } catch (NullPointerException e) {
-      throw new IllegalStateException(missingOpensMessage(), e);
-    }
-  }
-
-  public List<String> lines() {
-    try {
-      return resource.loadAsLines(StandardCharsets.UTF_8);
     } catch (NullPointerException e) {
       throw new IllegalStateException(missingOpensMessage(), e);
     }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/LocalJdbcMigrationResource.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/LocalJdbcMigrationResource.java
@@ -9,14 +9,14 @@ import io.ebean.migration.MigrationVersion;
  *
  * @author Roland Praml, FOCONIS AG
  */
-public class LocalJdbcMigrationResource extends LocalMigrationResource {
+final class LocalJdbcMigrationResource extends LocalMigrationResource {
 
   private final JdbcMigration migration;
 
   /**
    * Construct with version and resource.
    */
-  public LocalJdbcMigrationResource(MigrationVersion version, String location, JdbcMigration migration) {
+  LocalJdbcMigrationResource(MigrationVersion version, String location, JdbcMigration migration) {
     super(version, location);
     this.migration = migration;
   }
@@ -24,14 +24,14 @@ public class LocalJdbcMigrationResource extends LocalMigrationResource {
   /**
    * Return the migration
    */
-  public JdbcMigration getMigration() {
+  JdbcMigration migration() {
     return migration;
   }
 
   /**
    * Returns the checksum of the migration routine.
    */
-  public int getChecksum() {
+  int checksum() {
     if (migration instanceof MigrationChecksumProvider) {
       return ((MigrationChecksumProvider) migration).getChecksum();
     } else {

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -300,7 +300,7 @@ public final class MigrationTable {
       script = convertScript(local.content());
       checksum = Checksum.calculate(script);
     } else {
-      checksum = ((LocalJdbcMigrationResource) local).getChecksum();
+      checksum = ((LocalJdbcMigrationResource) local).checksum();
     }
 
     if (existing == null && patchInsertMigration(local, checksum)) {
@@ -406,7 +406,7 @@ public final class MigrationTable {
       log.log(DEBUG, "run migration {0}", local.location());
       scriptRunner.runScript(script, "run migration version: " + local.version());
     } else {
-      JdbcMigration migration = ((LocalJdbcMigrationResource) local).getMigration();
+      JdbcMigration migration = ((LocalJdbcMigrationResource) local).migration();
       log.log(INFO, "Executing jdbc migration version: {0} - {1}", local.version(), migration);
       migration.migrate(connection);
     }


### PR DESCRIPTION
These are currently publicly accessible and ideally are not. If there are issues with these being internal / package protected we need to adjust this.

Also removing the LocalDdlMigrationResource.lines() method. In theory this is not being used anywhere.