### PR TITLE
Make runner package internal

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/MigrationRunner.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/MigrationRunner.java
@@ -1,7 +1,7 @@
 package io.ebean.migration;
 
 import io.avaje.applog.AppLog;
-import io.ebean.migration.runner.*;
+import io.ebean.migration.runner.MigrationEngine;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -18,8 +18,6 @@ public class MigrationRunner {
   static final System.Logger log = AppLog.getLogger("io.ebean.migration");
 
   protected final MigrationConfig migrationConfig;
-
-  protected List<MigrationResource> checkMigrations;
 
   public MigrationRunner(MigrationConfig migrationConfig) {
     this.migrationConfig = migrationConfig;
@@ -43,8 +41,7 @@ public class MigrationRunner {
    * Return the migrations that would be applied if the migration is run.
    */
   public List<MigrationResource> checkState(Connection connection) {
-    run(connection, true);
-    return checkMigrations;
+    return run(connection, true);
   }
 
   /**
@@ -85,118 +82,8 @@ public class MigrationRunner {
   /**
    * Run the migrations if there are any that need running.
    */
-  protected void run(Connection connection, boolean checkStateOnly) {
-    try {
-      LocalMigrationResources resources = new LocalMigrationResources(migrationConfig);
-      if (!resources.readResources() && !resources.readInitResources()) {
-        log.log(DEBUG, "no migrations to check");
-        return;
-      }
-
-      long startMs = System.currentTimeMillis();
-      connection.setAutoCommit(false);
-      MigrationPlatform platform = derivePlatformName(migrationConfig, connection);
-      new MigrationSchema(migrationConfig, connection).createAndSetIfNeeded();
-
-      MigrationTable table = new MigrationTable(migrationConfig, connection, checkStateOnly, platform);
-      table.createIfNeededAndLock();
-      try {
-        List<LocalMigrationResource> migrations = resources.versions();
-        runMigrations(migrations, table, checkStateOnly);
-        connection.commit();
-        if (!checkStateOnly) {
-          long commitMs = System.currentTimeMillis();
-          log.log(INFO, "DB migrations completed in {0}ms - executed:{1} totalMigrations:{2}", (commitMs - startMs), table.count(), migrations.size());
-          int countNonTransactional = table.runNonTransactional();
-          if (countNonTransactional > 0) {
-            log.log(INFO, "Non-transactional DB migrations completed in {0}ms - executed:{1}", (System.currentTimeMillis() - commitMs), countNonTransactional);
-          }
-        }
-      } finally {
-        table.unlockMigrationTable();
-      }
-
-    } catch (MigrationException e) {
-      rollback(connection);
-      throw e;
-
-    } catch (Exception e) {
-      rollback(connection);
-      throw new RuntimeException(e);
-
-    } finally {
-      close(connection);
-    }
+  private List<MigrationResource> run(Connection connection, boolean checkStateOnly) {
+    return new MigrationEngine(migrationConfig).run(connection, checkStateOnly);
   }
 
-  /**
-   * Run all the migrations as needed.
-   */
-  private void runMigrations(List<LocalMigrationResource> localVersions, MigrationTable table, boolean checkStateMode) throws SQLException {
-    // get the migrations in version order
-    if (table.isEmpty()) {
-      LocalMigrationResource initVersion = getInitVersion();
-      if (initVersion != null) {
-        // run using a dbinit script
-        log.log(INFO, "dbinit migration version:{0}  local migrations:{1}  checkState:{2}", initVersion, localVersions.size(), checkStateMode);
-        checkMigrations = table.runInit(initVersion, localVersions);
-        return;
-      }
-    }
-    checkMigrations = table.runAll(localVersions);
-  }
-
-  /**
-   * Return the last init migration.
-   */
-  private LocalMigrationResource getInitVersion() {
-    LocalMigrationResources initResources = new LocalMigrationResources(migrationConfig);
-    if (initResources.readInitResources()) {
-      List<LocalMigrationResource> initVersions = initResources.versions();
-      if (!initVersions.isEmpty()) {
-        return initVersions.get(initVersions.size() - 1);
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Return the platform deriving from connection if required.
-   */
-  private MigrationPlatform derivePlatformName(MigrationConfig migrationConfig, Connection connection) {
-    final String platform = migrationConfig.getPlatform();
-    if (platform != null) {
-      return DbNameUtil.platform(platform);
-    }
-    // determine the platform from the db connection
-    String derivedPlatformName = DbNameUtil.normalise(connection);
-    migrationConfig.setPlatform(derivedPlatformName);
-    return DbNameUtil.platform(derivedPlatformName);
-  }
-
-  /**
-   * Close the connection logging if an error occurs.
-   */
-  private void close(Connection connection) {
-    try {
-      if (connection != null) {
-        connection.close();
-      }
-    } catch (SQLException e) {
-      log.log(WARNING, "Error closing connection", e);
-    }
-  }
-
-  /**
-   * Rollback the connection logging if an error occurs.
-   */
-  private void rollback(Connection connection) {
-    try {
-      if (connection != null) {
-        connection.rollback();
-      }
-    } catch (SQLException e) {
-      log.log(WARNING, "Error on connection rollback", e);
-    }
-  }
 }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/Checksum.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/Checksum.java
@@ -9,7 +9,7 @@ import java.util.zip.CRC32;
 /**
  * Calculates the checksum for the given string content.
  */
-class Checksum {
+final class Checksum {
 
   /**
    * Returns the checksum of the string content.

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/DbNameUtil.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/DbNameUtil.java
@@ -1,6 +1,4 @@
-package io.ebean.migration;
-
-import io.ebean.migration.runner.MigrationPlatform;
+package io.ebean.migration.runner;
 
 import java.sql.*;
 
@@ -61,7 +59,7 @@ class DbNameUtil implements DbPlatformNames {
         }
       }
     } catch (SQLException e) {
-      MigrationRunner.log.log(WARNING, "Error running detection query on Postgres", e);
+      MigrationEngine.log.log(WARNING, "Error running detection query on Postgres", e);
     }
     return POSTGRES;
   }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/DbPlatformNames.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/DbPlatformNames.java
@@ -1,4 +1,4 @@
-package io.ebean.migration;
+package io.ebean.migration.runner;
 
 /**
  * Known database platform names.

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/LocalMigrationResource.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/LocalMigrationResource.java
@@ -6,7 +6,7 @@ import io.ebean.migration.MigrationVersion;
 /**
  * A DB migration resource (DDL or Jdbc)
  */
-public abstract class LocalMigrationResource implements MigrationResource {
+abstract class LocalMigrationResource implements MigrationResource {
 
   protected final MigrationVersion version;
 
@@ -17,12 +17,13 @@ public abstract class LocalMigrationResource implements MigrationResource {
   /**
    * Construct with version and resource.
    */
-  public LocalMigrationResource(MigrationVersion version, String location) {
+  LocalMigrationResource(MigrationVersion version, String location) {
     this.version = version;
     this.location = location;
     this.type = version.type();
   }
 
+  @Override
   public String toString() {
     return version.toString();
   }
@@ -30,21 +31,21 @@ public abstract class LocalMigrationResource implements MigrationResource {
   /**
    * Return true if the underlying version is "repeatable".
    */
-  public boolean isRepeatable() {
+  boolean isRepeatable() {
     return version.isRepeatable();
   }
 
   /**
    * Return true if the underlying version is "repeatable init".
    */
-  public boolean isRepeatableInit() {
+  boolean isRepeatableInit() {
     return version.isRepeatableInit();
   }
 
   /**
    * Return true if the underlying version is "repeatable last".
    */
-  public boolean isRepeatableLast() {
+  boolean isRepeatableLast() {
     return version.isRepeatableLast();
   }
 
@@ -87,7 +88,7 @@ public abstract class LocalMigrationResource implements MigrationResource {
   /**
    * Set the migration to be an Init migration.
    */
-  public void setInitType() {
+  void setInitType() {
     this.type = MigrationVersion.BOOTINIT_TYPE;
   }
 }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/LocalMigrationResources.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/LocalMigrationResources.java
@@ -16,7 +16,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 /**
  * Loads the DB migration resources and sorts them into execution order.
  */
-public final class LocalMigrationResources {
+final class LocalMigrationResources {
 
   private static final System.Logger log = MigrationSchema.log;
 
@@ -28,7 +28,7 @@ public final class LocalMigrationResources {
   /**
    * Construct with configuration options.
    */
-  public LocalMigrationResources(MigrationConfig migrationConfig) {
+  LocalMigrationResources(MigrationConfig migrationConfig) {
     this.migrationConfig = migrationConfig;
     this.classLoader = migrationConfig.getClassLoader();
     this.searchForJdbcMigrations = migrationConfig.getJdbcMigrationFactory() != null;
@@ -37,14 +37,14 @@ public final class LocalMigrationResources {
   /**
    * Read the init migration resources (usually only 1) returning true if there are versions.
    */
-  public boolean readInitResources() {
+  boolean readInitResources() {
     return readResourcesForPath(migrationConfig.getMigrationInitPath());
   }
 
   /**
    * Read all the migration resources (SQL scripts) returning true if there are versions.
    */
-  public boolean readResources() {
+  boolean readResources() {
     return readResourcesForPath(migrationConfig.getMigrationPath());
   }
 
@@ -134,14 +134,14 @@ public final class LocalMigrationResources {
   /**
    * Return the list of migration resources in version order.
    */
-  public List<LocalMigrationResource> versions() {
+  List<LocalMigrationResource> versions() {
     return versions;
   }
 
   /**
    * Filter used to find the migration scripts.
    */
-  private static class Match implements Predicate<String> {
+  private static final class Match implements Predicate<String> {
 
     private final boolean searchJdbc;
 
@@ -158,7 +158,7 @@ public final class LocalMigrationResources {
   /**
    * Filter to find JDBC migrations only.
    */
-  private static class JdbcOnly implements Predicate<String> {
+  private static final class JdbcOnly implements Predicate<String> {
     @Override
     public boolean test(String name) {
       return name.endsWith(".class") && !name.contains("$");

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationEngine.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationEngine.java
@@ -1,0 +1,149 @@
+package io.ebean.migration.runner;
+
+import io.avaje.applog.AppLog;
+import io.ebean.migration.MigrationConfig;
+import io.ebean.migration.MigrationException;
+import io.ebean.migration.MigrationResource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+import static java.lang.System.Logger.Level.*;
+import static java.lang.System.Logger.Level.WARNING;
+
+/**
+ * Actually runs the migrations.
+ */
+public class MigrationEngine {
+
+  static final System.Logger log = AppLog.getLogger("io.ebean.migration");
+
+  private final MigrationConfig migrationConfig;
+
+  /**
+   * Create with the MigrationConfig.
+   */
+  public MigrationEngine(MigrationConfig migrationConfig) {
+    this.migrationConfig = migrationConfig;
+  }
+
+  /**
+   * Run the migrations if there are any that need running.
+   */
+  public List<MigrationResource> run(Connection connection, boolean checkStateOnly) {
+    try {
+      LocalMigrationResources resources = new LocalMigrationResources(migrationConfig);
+      if (!resources.readResources() && !resources.readInitResources()) {
+        log.log(DEBUG, "no migrations to check");
+        return Collections.emptyList();
+      }
+
+      long startMs = System.currentTimeMillis();
+      connection.setAutoCommit(false);
+      MigrationPlatform platform = derivePlatformName(migrationConfig, connection);
+      new MigrationSchema(migrationConfig, connection).createAndSetIfNeeded();
+
+      MigrationTable table = new MigrationTable(migrationConfig, connection, checkStateOnly, platform);
+      table.createIfNeededAndLock();
+      try {
+        List<LocalMigrationResource> migrations = resources.versions();
+        List<MigrationResource> result = runMigrations(migrations, table, checkStateOnly);
+        connection.commit();
+        if (!checkStateOnly) {
+          long commitMs = System.currentTimeMillis();
+          log.log(INFO, "DB migrations completed in {0}ms - executed:{1} totalMigrations:{2}", (commitMs - startMs), table.count(), migrations.size());
+          int countNonTransactional = table.runNonTransactional();
+          if (countNonTransactional > 0) {
+            log.log(INFO, "Non-transactional DB migrations completed in {0}ms - executed:{1}", (System.currentTimeMillis() - commitMs), countNonTransactional);
+          }
+        }
+        return result;
+      } finally {
+        table.unlockMigrationTable();
+      }
+
+    } catch (MigrationException e) {
+      rollback(connection);
+      throw e;
+
+    } catch (Exception e) {
+      rollback(connection);
+      throw new RuntimeException(e);
+
+    } finally {
+      close(connection);
+    }
+  }
+
+  /**
+   * Run all the migrations as needed.
+   */
+  private List<MigrationResource> runMigrations(List<LocalMigrationResource> localVersions, MigrationTable table, boolean checkStateMode) throws SQLException {
+    // get the migrations in version order
+    if (table.isEmpty()) {
+      LocalMigrationResource initVersion = getInitVersion();
+      if (initVersion != null) {
+        // run using a dbinit script
+        log.log(INFO, "dbinit migration version:{0}  local migrations:{1}  checkState:{2}", initVersion, localVersions.size(), checkStateMode);
+        return table.runInit(initVersion, localVersions);
+      }
+    }
+    return table.runAll(localVersions);
+  }
+
+  /**
+   * Return the last init migration.
+   */
+  private LocalMigrationResource getInitVersion() {
+    LocalMigrationResources initResources = new LocalMigrationResources(migrationConfig);
+    if (initResources.readInitResources()) {
+      List<LocalMigrationResource> initVersions = initResources.versions();
+      if (!initVersions.isEmpty()) {
+        return initVersions.get(initVersions.size() - 1);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Return the platform deriving from connection if required.
+   */
+  private MigrationPlatform derivePlatformName(MigrationConfig migrationConfig, Connection connection) {
+    final String platform = migrationConfig.getPlatform();
+    if (platform != null) {
+      return DbNameUtil.platform(platform);
+    }
+    // determine the platform from the db connection
+    String derivedPlatformName = DbNameUtil.normalise(connection);
+    migrationConfig.setPlatform(derivedPlatformName);
+    return DbNameUtil.platform(derivedPlatformName);
+  }
+
+  /**
+   * Close the connection logging if an error occurs.
+   */
+  private void close(Connection connection) {
+    try {
+      if (connection != null) {
+        connection.close();
+      }
+    } catch (SQLException e) {
+      log.log(WARNING, "Error closing connection", e);
+    }
+  }
+
+  /**
+   * Rollback the connection logging if an error occurs.
+   */
+  private void rollback(Connection connection) {
+    try {
+      if (connection != null) {
+        connection.rollback();
+      }
+    } catch (SQLException e) {
+      log.log(WARNING, "Error on connection rollback", e);
+    }
+  }
+}

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationMetaRow.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationMetaRow.java
@@ -9,7 +9,7 @@ import java.sql.Timestamp;
 /**
  * Bean holding migration execution details stored in the migration table.
  */
-class MigrationMetaRow {
+final class MigrationMetaRow {
 
   private final int id;
   //private String status;

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
@@ -11,7 +11,7 @@ import static java.lang.System.Logger.Level.*;
 /**
  * Handle database platform specific locking on db migration table.
  */
-public class MigrationPlatform {
+class MigrationPlatform {
 
   private static final System.Logger log = MigrationTable.log;
 
@@ -106,7 +106,7 @@ public class MigrationPlatform {
     return BASE_SELECT_ALL + table + forUpdateSuffix;
   }
 
-  public static class LogicalLock extends MigrationPlatform {
+  static final class LogicalLock extends MigrationPlatform {
 
     @Override
     void lockMigrationTable(String sqlTable, Connection connection) throws SQLException {
@@ -150,7 +150,7 @@ public class MigrationPlatform {
     }
   }
 
-  public static class Postgres extends MigrationPlatform {
+  static final class Postgres extends MigrationPlatform {
 
     @Override
     DdlDetect ddlDetect() {
@@ -168,7 +168,7 @@ public class MigrationPlatform {
   /**
    * MySql and MariaDB need to use named locks due to implicit commits with DDL.
    */
-  public static class MySql extends MigrationPlatform {
+  static final class MySql extends MigrationPlatform {
 
     @Override
     void lockMigrationTable(String sqlTable, Connection connection) throws SQLException {
@@ -199,16 +199,16 @@ public class MigrationPlatform {
     }
   }
 
-  public static class SqlServer extends MigrationPlatform {
+  static final class SqlServer extends MigrationPlatform {
 
-    public SqlServer() {
+    SqlServer() {
       this.forUpdateSuffix = " with (updlock) order by id";
     }
   }
 
-  public static class NoLocking extends MigrationPlatform {
+  static final class NoLocking extends MigrationPlatform {
 
-    public NoLocking() {
+    NoLocking() {
       this.forUpdateSuffix = " order by id";
     }
 

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationSchema.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationSchema.java
@@ -14,7 +14,7 @@ import static java.lang.System.Logger.Level.INFO;
 /**
  * Create Schema if needed and set current Schema in Migration
  */
-public final class MigrationSchema {
+final class MigrationSchema {
 
   static final System.Logger log = AppLog.getLogger("io.ebean.migration");
 
@@ -26,7 +26,7 @@ public final class MigrationSchema {
   /**
    * Construct with configuration and connection.
    */
-  public MigrationSchema(MigrationConfig migrationConfig, Connection connection) {
+  MigrationSchema(MigrationConfig migrationConfig, Connection connection) {
     this.dbSchema = trim(migrationConfig.getDbSchema());
     this.createSchemaIfNotExists = migrationConfig.isCreateSchemaIfNotExists();
     this.setCurrentSchema = migrationConfig.isSetCurrentSchema();
@@ -40,7 +40,7 @@ public final class MigrationSchema {
   /**
    * Create and set the DB schema if desired.
    */
-  public void createAndSetIfNeeded() throws SQLException {
+  void createAndSetIfNeeded() throws SQLException {
     if (dbSchema != null) {
       log.log(DEBUG, "Migration using schema: {0}", dbSchema);
       if (createSchemaIfNotExists) {

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -16,7 +16,7 @@ import static java.lang.System.Logger.Level.*;
 /**
  * Manages the migration table.
  */
-public final class MigrationTable {
+final class MigrationTable {
 
   static final System.Logger log = AppLog.getLogger("io.ebean.DDL");
 
@@ -69,7 +69,7 @@ public final class MigrationTable {
   /**
    * Construct with server, configuration and jdbc connection (DB admin user).
    */
-  public MigrationTable(MigrationConfig config, Connection connection, boolean checkStateOnly, MigrationPlatform platform) {
+  MigrationTable(MigrationConfig config, Connection connection, boolean checkStateOnly, MigrationPlatform platform) {
     this.platform = platform;
     this.connection = connection;
     this.scriptRunner = new MigrationScriptRunner(connection, platform);
@@ -114,14 +114,14 @@ public final class MigrationTable {
   /**
    * Return the number of migrations in the DB migration table.
    */
-  public int size() {
+  int size() {
     return migrations.size();
   }
 
   /**
    * Returns the versions that are already applied.
    */
-  public Set<String> versions() {
+  Set<String> versions() {
     return migrations.keySet();
   }
 
@@ -138,7 +138,7 @@ public final class MigrationTable {
    * Also holds DB lock on migration table and loads existing migrations.
    * </p>
    */
-  public void createIfNeededAndLock() throws SQLException, IOException {
+  void createIfNeededAndLock() throws SQLException, IOException {
     SQLException sqlEx = null;
     if (!tableExists()) {
       try {
@@ -176,7 +176,7 @@ public final class MigrationTable {
   /**
    * Release a lock on the migration table (MySql, MariaDB only).
    */
-  public void unlockMigrationTable() throws SQLException {
+  void unlockMigrationTable() throws SQLException {
     platform.unlockMigrationTable(sqlTable, connection);
   }
 
@@ -480,7 +480,7 @@ public final class MigrationTable {
   /**
    * Return true if there are no migrations.
    */
-  public boolean isEmpty() {
+  boolean isEmpty() {
     return migrations.isEmpty();
   }
 
@@ -489,7 +489,7 @@ public final class MigrationTable {
    *
    * @return the migrations that have been run (collected if checkState is true).
    */
-  public List<MigrationResource> runAll(List<LocalMigrationResource> localVersions) throws SQLException {
+  List<MigrationResource> runAll(List<LocalMigrationResource> localVersions) throws SQLException {
     checkMinVersion();
     for (LocalMigrationResource localVersion : localVersions) {
       if (!localVersion.isRepeatable() && dbInitVersion != null && dbInitVersion.compareTo(localVersion.version()) >= 0) {
@@ -517,7 +517,7 @@ public final class MigrationTable {
    *
    * @return the migrations that have been run (collected if checkstate is true).
    */
-  public List<MigrationResource> runInit(LocalMigrationResource initVersion, List<LocalMigrationResource> localVersions) throws SQLException {
+  List<MigrationResource> runInit(LocalMigrationResource initVersion, List<LocalMigrationResource> localVersions) throws SQLException {
     runRepeatableInit(localVersions);
     initVersion.setInitType();
     if (!shouldRun(initVersion, null)) {
@@ -548,14 +548,14 @@ public final class MigrationTable {
    * as such the migration isn't truely atomic - the migration can run and
    * complete and the non-transactional statements fail.
    */
-  public int runNonTransactional() {
+  int runNonTransactional() {
     return scriptRunner.runNonTransactional();
   }
 
   /**
    * Return the count of migrations that were run.
    */
-  public int count() {
+  int count() {
     return executionCount;
   }
 }

--- a/ebean-migration/src/main/java/module-info.java
+++ b/ebean-migration/src/main/java/module-info.java
@@ -1,7 +1,6 @@
 open module io.ebean.migration {
 
   exports io.ebean.migration;
-  exports io.ebean.migration.runner;
 
   requires transitive java.sql;
   requires transitive io.avaje.applog;

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/DbNameUtilTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/DbNameUtilTest.java
@@ -1,5 +1,6 @@
-package io.ebean.migration;
+package io.ebean.migration.runner;
 
+import io.ebean.migration.MigrationConfig;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable1Test.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable1Test.java
@@ -1,7 +1,7 @@
-package io.ebean.migration;
+package io.ebean.migration.runner;
 
-import io.ebean.migration.runner.MigrationPlatform;
-import io.ebean.migration.runner.MigrationTable;
+import io.ebean.migration.MigrationConfig;
+import io.ebean.migration.MigrationRunner;
 import io.ebean.datasource.DataSourceConfig;
 import io.ebean.datasource.DataSourcePool;
 import io.ebean.datasource.DataSourceFactory;
@@ -17,7 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MigrationTableTest {
+public class MigrationTable1Test {
 
   private static MigrationConfig config;
   private static DataSourcePool dataSource;

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable2Test.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable2Test.java
@@ -1,6 +1,5 @@
 package io.ebean.migration.runner;
 
-import io.ebean.migration.DbPlatformNames;
 import io.ebean.migration.MigrationConfig;
 import io.ebean.migration.MigrationVersion;
 import org.junit.jupiter.api.Test;
@@ -9,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MigrationTableTest {
+public class MigrationTable2Test {
 
   @Test
   void testCreateTableDdl() throws Exception {

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableAsyncTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableAsyncTest.java
@@ -1,11 +1,11 @@
-package io.ebean.migration;
+package io.ebean.migration.runner;
 
 import io.ebean.datasource.DataSourceConfig;
 import io.ebean.datasource.DataSourceFactory;
 import io.ebean.datasource.DataSourcePool;
 import io.ebean.docker.commands.*;
-import io.ebean.migration.runner.MigrationPlatform;
-import io.ebean.migration.runner.MigrationTable;
+import io.ebean.migration.MigrationConfig;
+import io.ebean.migration.MigrationRunner;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -49,7 +49,7 @@ public class MigrationTableAsyncTest {
     // as soon as reorg table is executed, all locks held by the current
     // connection are dropped
     // See comment in 1.1__initial.sql
-    
+
     Db2Container container = Db2Container.builder("latest")
       .port(50055)
       .containerName("mig_async_db2")

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableTestDb2.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableTestDb2.java
@@ -1,7 +1,6 @@
-package io.ebean.migration;
+package io.ebean.migration.runner;
 
-import io.ebean.migration.runner.MigrationPlatform;
-import io.ebean.migration.runner.MigrationTable;
+import io.ebean.migration.MigrationConfig;
 import io.ebean.datasource.DataSourceConfig;
 import io.ebean.datasource.DataSourcePool;
 import io.ebean.datasource.DataSourceFactory;


### PR DESCRIPTION
- Do not export runner package
- Move logic in MigrationRunner into MigrationEngine
- Make most types in runner package final and package protected