### PR TITLE
Modify JdbcMigration interface to extend MigrationChecksumProvider

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/JdbcMigration.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/JdbcMigration.java
@@ -14,10 +14,15 @@ import java.sql.Connection;
  *
  * @author Roland Praml, FOCONIS AG
  */
-public interface JdbcMigration {
+public interface JdbcMigration extends MigrationChecksumProvider {
 
   /**
    * Execute the migration using the connection.
    */
   void migrate(Connection connection);
+
+  @Override
+  default int getChecksum() {
+    return 0;
+  }
 }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/LocalJdbcMigrationResource.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/LocalJdbcMigrationResource.java
@@ -1,7 +1,6 @@
 package io.ebean.migration.runner;
 
 import io.ebean.migration.JdbcMigration;
-import io.ebean.migration.MigrationChecksumProvider;
 import io.ebean.migration.MigrationVersion;
 
 /**
@@ -32,11 +31,7 @@ final class LocalJdbcMigrationResource extends LocalMigrationResource {
    * Returns the checksum of the migration routine.
    */
   int checksum() {
-    if (migration instanceof MigrationChecksumProvider) {
-      return ((MigrationChecksumProvider) migration).getChecksum();
-    } else {
-      return 0; // maybe we can build a checksum over the byte code, but this may change on different java versions.
-    }
+    return migration.getChecksum();
   }
 
   @Override


### PR DESCRIPTION
This provides some simplification in LocalJdbcMigrationResource.
At some point we should be able to remove MigrationChecksumProvider altogether.