### PR TITLE
Fix such that there is a rollback() before LogicalLock unlock()

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationEngine.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationEngine.java
@@ -56,6 +56,9 @@ public class MigrationEngine {
           }
         }
         return result;
+      } catch (MigrationException e) {
+        rollback(connection);
+        throw e;
       } catch (Exception e) {
         log.log(ERROR, "Perform rollback due to DB migration error", e);
         rollback(connection);
@@ -143,7 +146,7 @@ public class MigrationEngine {
   /**
    * Rollback the connection logging if an error occurs.
    */
-  private void rollback(Connection connection) {
+  static void rollback(Connection connection) {
     try {
       if (connection != null) {
         connection.rollback();

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
@@ -1,6 +1,7 @@
 package io.ebean.migration.runner;
 
 import io.ebean.ddlrunner.DdlDetect;
+import io.ebean.migration.MigrationException;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ class MigrationPlatform {
     return DdlDetect.NONE;
   }
 
-  void unlockMigrationTable(String sqlTable, Connection connection) throws SQLException {
+  void unlockMigrationTable(String sqlTable, Connection connection) {
     // do nothing by default for select for update case
   }
 
@@ -118,9 +119,14 @@ class MigrationPlatform {
     }
 
     @Override
-    void unlockMigrationTable(String sqlTable, Connection connection) throws SQLException {
-      releaseLogicalLock(sqlTable, connection);
-      connection.commit();
+    void unlockMigrationTable(String sqlTable, Connection connection) {
+      try {
+        releaseLogicalLock(sqlTable, connection);
+        connection.commit();
+      } catch (SQLException e) {
+        rollback(connection);
+        throw new MigrationException("Error releasing logical lock for ebean migrations");
+      }
     }
 
     private boolean obtainLogicalLock(String sqlTable, Connection connection) throws SQLException {
@@ -190,11 +196,16 @@ class MigrationPlatform {
       return false;
     }
 
+    @SuppressWarnings("all")
     @Override
-    void unlockMigrationTable(String sqlTable, Connection connection) throws SQLException {
-      String hash = Integer.toHexString(connection.getMetaData().getURL().hashCode());
-      try (Statement query = connection.createStatement()) {
-        query.execute("select release_lock('ebean_migration-" + hash + "')");
+    void unlockMigrationTable(String sqlTable, Connection connection) {
+      try {
+        String hash = Integer.toHexString(connection.getMetaData().getURL().hashCode());
+        try (Statement query = connection.createStatement()) {
+          query.execute("select release_lock('ebean_migration-" + hash + "')");
+        }
+      } catch (SQLException e) {
+        throw new MigrationException("Error releasing lock for ebean_migration", e);
       }
     }
   }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
@@ -12,6 +12,7 @@ import static java.lang.System.Logger.Level.*;
 /**
  * Handle database platform specific locking on db migration table.
  */
+@SuppressWarnings({"SqlDialectInspection", "SqlSourceToSinkFlow"})
 class MigrationPlatform {
 
   private static final System.Logger log = MigrationTable.log;
@@ -124,7 +125,7 @@ class MigrationPlatform {
         releaseLogicalLock(sqlTable, connection);
         connection.commit();
       } catch (SQLException e) {
-        rollback(connection);
+        MigrationEngine.rollback(connection);
         throw new MigrationException("Error releasing logical lock for ebean migrations");
       }
     }
@@ -196,7 +197,6 @@ class MigrationPlatform {
       return false;
     }
 
-    @SuppressWarnings("all")
     @Override
     void unlockMigrationTable(String sqlTable, Connection connection) {
       try {

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -176,7 +176,7 @@ final class MigrationTable {
   /**
    * Release a lock on the migration table (MySql, MariaDB only).
    */
-  void unlockMigrationTable() throws SQLException {
+  void unlockMigrationTable() {
     platform.unlockMigrationTable(sqlTable, connection);
   }
 

--- a/ebean-migration/src/test/resources/dbmig_error/1.1__initial.sql
+++ b/ebean-migration/src/test/resources/dbmig_error/1.1__initial.sql
@@ -1,0 +1,1 @@
+create table m1 (id integer, acol varchar(20));

--- a/ebean-migration/src/test/resources/dbmig_error/1.2__insert.sql
+++ b/ebean-migration/src/test/resources/dbmig_error/1.2__insert.sql
@@ -1,0 +1,1 @@
+insert into m1 (id, acol) values (1,'hi');

--- a/ebean-migration/src/test/resources/dbmig_error/1.3__error.sql
+++ b/ebean-migration/src/test/resources/dbmig_error/1.3__error.sql
@@ -1,0 +1,1 @@
+not valid sql


### PR DESCRIPTION
When there is an error during migration and using logical lock
then ensure there is a rollback before the unlock() on the logical
lock.