### PR TITLE
Reduce columns selected for existing migrations to id, type, version and checksum

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationMetaRow.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationMetaRow.java
@@ -9,13 +9,13 @@ import java.sql.Timestamp;
 /**
  * Bean holding migration execution details stored in the migration table.
  */
+@SuppressWarnings("SqlSourceToSinkFlow")
 final class MigrationMetaRow {
 
   private final int id;
-  //private String status;
   private final String type;
   private final String version;
-  private final String comment;
+  private String comment;
   private int checksum;
   private Timestamp runOn;
   private String runBy;
@@ -41,18 +41,13 @@ final class MigrationMetaRow {
   MigrationMetaRow(ResultSet row) throws SQLException {
     id = row.getInt(1);
     type = row.getString(2);
-    //status = row.getString(3);
-    version = row.getString(4);
-    comment = row.getString(5);
-    checksum = row.getInt(6);
-    runOn = row.getTimestamp(7);
-    runBy = row.getString(8);
-    runTime = row.getLong(9);
+    version = row.getString(3);
+    checksum = row.getInt(4);
   }
 
   @Override
   public String toString() {
-    return "id:" + id + " type:" + type + " checksum:" + checksum + " runVersion:" + version + " comment:" + comment + " runOn:" + runOn + " runBy:" + runBy;
+    return "id:" + id + " type:" + type + " checksum:" + checksum + " version:" + version;
   }
 
   /**
@@ -111,8 +106,7 @@ final class MigrationMetaRow {
    */
   static String insertSql(String table) {
     return "insert into " + table
-      + " (id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time)"
-      + " values (?,?,?,?,?,?,?,?,?)";
+      + " (id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time) values (?,?,?,?,?,?,?,?,?)";
   }
 
   /**
@@ -120,8 +114,7 @@ final class MigrationMetaRow {
    */
   static String updateSql(String table) {
     return "update " + table
-      + " set mchecksum=?, run_on=?, run_by=?, run_time=? "
-      + " where id = ?";
+      + " set mchecksum=?, run_on=?, run_by=?, run_time=? where id = ?";
   }
 
   /**

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationPlatform.java
@@ -18,7 +18,7 @@ class MigrationPlatform {
   private static final System.Logger log = MigrationTable.log;
 
   private static final String BASE_SELECT_ID = "select id from ";
-  private static final String BASE_SELECT_ALL = "select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from ";
+  private static final String BASE_SELECT = "select id, mtype, mversion, mchecksum from ";
 
   /**
    * Standard row locking for db migration table.
@@ -105,7 +105,7 @@ class MigrationPlatform {
    * Return the SQL to read the db migration table.
    */
   String sqlSelectForReading(String table) {
-    return BASE_SELECT_ALL + table + forUpdateSuffix;
+    return BASE_SELECT + table + forUpdateSuffix;
   }
 
   static final class LogicalLock extends MigrationPlatform {

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationMetaRowTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationMetaRowTest.java
@@ -5,26 +5,26 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class MigrationMetaRowTest {
+class MigrationMetaRowTest {
 
   @Test
   void testSelectSql() {
 
     final MigrationPlatform sqlServer = new MigrationPlatform.SqlServer();
     String sql = sqlServer.sqlSelectForReading("someTable");
-    assertThat(sql).isEqualTo("select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from someTable with (updlock) order by id");
+    assertThat(sql).isEqualTo("select id, mtype, mversion, mchecksum from someTable with (updlock) order by id");
 
     final MigrationPlatform noLocking = new MigrationPlatform.NoLocking();
     sql = noLocking.sqlSelectForReading("someTable");
-    assertThat(sql).isEqualTo("select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from someTable order by id");
+    assertThat(sql).isEqualTo("select id, mtype, mversion, mchecksum from someTable order by id");
 
     final MigrationPlatform postgres = new MigrationPlatform.Postgres();
     sql = postgres.sqlSelectForReading("someTable");
-    assertThat(sql).isEqualTo("select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from someTable order by id for update");
+    assertThat(sql).isEqualTo("select id, mtype, mversion, mchecksum from someTable order by id for update");
 
     final MigrationPlatform defaultPlatform = new MigrationPlatform();
     sql = defaultPlatform.sqlSelectForReading("someTable");
-    assertThat(sql).isEqualTo("select id, mtype, mstatus, mversion, mcomment, mchecksum, run_on, run_by, run_time from someTable order by id for update");
+    assertThat(sql).isEqualTo("select id, mtype, mversion, mchecksum from someTable order by id for update");
   }
 
 }


### PR DESCRIPTION
Exclude the status, comment, run_on, run_by, run_time as these are not being used.