### PR TITLE
Add a fastMode for the common case when there are no new migrations to run

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/MigrationConfig.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/MigrationConfig.java
@@ -66,6 +66,7 @@ public class MigrationConfig {
   private String platform;
   private Properties properties;
   private boolean earlyChecksumMode;
+  private boolean fastMode;
 
   /**
    * Return the name of the migration table.
@@ -468,6 +469,7 @@ public class MigrationConfig {
     dbPassword = property("password", dbPassword);
     dbUrl = property("url", dbUrl);
     dbSchema = property("schema", dbSchema);
+    fastMode = property("fastMode", fastMode);
     skipMigrationRun = property("skipMigrationRun", skipMigrationRun);
     skipChecksum = property("skipChecksum", skipChecksum);
     earlyChecksumMode = property("earlyChecksumMode", earlyChecksumMode);
@@ -590,6 +592,22 @@ public class MigrationConfig {
    */
   public void setEarlyChecksumMode(boolean earlyChecksumMode) {
     this.earlyChecksumMode = earlyChecksumMode;
+  }
+
+  /**
+   * Return true if fastMode is turned on.
+   */
+  public boolean isFastMode() {
+    return fastMode;
+  }
+
+  /**
+   * Set true to enable fastMode. This will perform an initial check for the exact same number
+   * of migrations and matching checksums without any locking. If anything does not match
+   * then the normal migration is performed with appropriate locking etc.
+   */
+  public void setFastMode(boolean fastMode) {
+    this.fastMode = fastMode;
   }
 
   /**

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationEngine.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationEngine.java
@@ -9,6 +9,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.lang.System.Logger.Level.*;
 import static java.lang.System.Logger.Level.WARNING;
@@ -22,6 +24,9 @@ public class MigrationEngine {
 
   private final MigrationConfig migrationConfig;
   private final boolean checkStateOnly;
+  private final boolean fastMode;
+  private int fastModeCount;
+  private MigrationTable table;
 
   /**
    * Create with the MigrationConfig.
@@ -29,6 +34,7 @@ public class MigrationEngine {
   public MigrationEngine(MigrationConfig migrationConfig, boolean checkStateOnly) {
     this.migrationConfig = migrationConfig;
     this.checkStateOnly = checkStateOnly;
+    this.fastMode = !checkStateOnly && migrationConfig.isFastMode();
   }
 
   /**
@@ -41,11 +47,18 @@ public class MigrationEngine {
         log.log(DEBUG, "no migrations to check");
         return Collections.emptyList();
       }
-
       long startMs = System.currentTimeMillis();
-      MigrationTable table = initialiseMigrationTable(connection);
+      setAutoCommitFalse(connection);
+      table = initMigrationTable(connection);
+      if (fastMode && fastModeCheck(resources.versions())) {
+        long checkMs = System.currentTimeMillis() - startMs;
+        log.log(INFO, "DB migrations completed in {0}ms - totalMigrations:{1}", checkMs, fastModeCount);
+        return Collections.emptyList();
+      }
+
+      initialiseMigrationTable(connection);
       try {
-        List<MigrationResource> result = runMigrations(resources.versions(), table, checkStateOnly);
+        List<MigrationResource> result = runMigrations(resources.versions());
         connection.commit();
         if (!checkStateOnly) {
           long commitMs = System.currentTimeMillis();
@@ -71,15 +84,65 @@ public class MigrationEngine {
     }
   }
 
-  private MigrationTable initialiseMigrationTable(Connection connection) {
+  private static void setAutoCommitFalse(Connection connection) {
     try {
       connection.setAutoCommit(false);
-      MigrationPlatform platform = derivePlatformName(migrationConfig, connection);
-      new MigrationSchema(migrationConfig, connection).createAndSetIfNeeded();
+    } catch (SQLException e) {
+      throw new MigrationException("Error running DB migrations", e);
+    }
+  }
 
-      final MigrationTable table = new MigrationTable(migrationConfig, connection, checkStateOnly, platform);
+  private MigrationTable initMigrationTable(Connection connection) {
+    final MigrationPlatform platform = derivePlatformName(migrationConfig, connection);
+    return new MigrationTable(migrationConfig, connection, checkStateOnly, platform);
+  }
+
+  private boolean fastModeCheck(List<LocalMigrationResource> versions) {
+    try {
+      final List<MigrationMetaRow> rows = table.fastRead();
+      if (rows.size() != versions.size() + 1) {
+        // difference in count of migrations
+        return false;
+      }
+      final Map<String, Integer> dbChecksums = dbChecksumMap(rows);
+      for (LocalMigrationResource local : versions) {
+        Integer dbChecksum = dbChecksums.get(local.key());
+        if (dbChecksum == null) {
+          // no match, unexpected missing migration
+          return false;
+        }
+        int localChecksum = checksumFor(local);
+        if (localChecksum != dbChecksum) {
+          // no match, perhaps repeatable migration change
+          return false;
+        }
+      }
+      // successful fast check
+      fastModeCount = versions.size();
+      return true;
+    } catch (SQLException e) {
+      // probably migration table does not exist
+      return false;
+    }
+  }
+
+  private static Map<String, Integer> dbChecksumMap(List<MigrationMetaRow> rows) {
+    return rows.stream().collect(Collectors.toMap(MigrationMetaRow::version, MigrationMetaRow::checksum));
+  }
+
+  private int checksumFor(LocalMigrationResource local) {
+    if (local instanceof LocalUriMigrationResource) {
+      return ((LocalUriMigrationResource)local).checksum();
+    } else if (local instanceof LocalDdlMigrationResource) {
+      return Checksum.calculate(local.content());
+    } else {
+      return ((LocalJdbcMigrationResource) local).checksum();
+    }
+  }
+
+  private void initialiseMigrationTable(Connection connection) {
+    try {
       table.createIfNeededAndLock();
-      return table;
     } catch (Throwable e) {
       rollback(connection);
       throw new MigrationException("Error initialising db migrations table", e);
@@ -89,13 +152,13 @@ public class MigrationEngine {
   /**
    * Run all the migrations as needed.
    */
-  private List<MigrationResource> runMigrations(List<LocalMigrationResource> localVersions, MigrationTable table, boolean checkStateMode) throws SQLException {
+  private List<MigrationResource> runMigrations(List<LocalMigrationResource> localVersions) throws SQLException {
     // get the migrations in version order
     if (table.isEmpty()) {
       LocalMigrationResource initVersion = lastInitVersion();
       if (initVersion != null) {
         // run using a dbinit script
-        log.log(INFO, "dbinit migration version:{0}  local migrations:{1}  checkState:{2}", initVersion, localVersions.size(), checkStateMode);
+        log.log(INFO, "dbinit migration version:{0}  local migrations:{1}  checkState:{2}", initVersion, localVersions.size(), checkStateOnly);
         return table.runInit(initVersion, localVersions);
       }
     }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationMetaRow.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationMetaRow.java
@@ -12,8 +12,8 @@ import java.sql.Timestamp;
 @SuppressWarnings("SqlSourceToSinkFlow")
 final class MigrationMetaRow {
 
-  private final int id;
-  private final String type;
+  private int id;
+  private String type;
   private final String version;
   private String comment;
   private int checksum;
@@ -43,6 +43,17 @@ final class MigrationMetaRow {
     type = row.getString(2);
     version = row.getString(3);
     checksum = row.getInt(4);
+  }
+
+  private MigrationMetaRow(int checksum, String version) {
+    this.checksum = checksum;
+    this.version = version;
+  }
+
+  static MigrationMetaRow fastRead(ResultSet row) throws SQLException {
+    final var checksum = row.getInt(1);
+    final var version = row.getString(2);
+    return new MigrationMetaRow(checksum, version);
   }
 
   @Override

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationSchema.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationSchema.java
@@ -26,11 +26,15 @@ final class MigrationSchema {
   /**
    * Construct with configuration and connection.
    */
-  MigrationSchema(MigrationConfig migrationConfig, Connection connection) {
+  private MigrationSchema(MigrationConfig migrationConfig, Connection connection) {
     this.dbSchema = trim(migrationConfig.getDbSchema());
     this.createSchemaIfNotExists = migrationConfig.isCreateSchemaIfNotExists();
     this.setCurrentSchema = migrationConfig.isSetCurrentSchema();
     this.connection = connection;
+  }
+
+  static void createIfNeeded(MigrationConfig config, Connection connection) throws SQLException {
+    new MigrationSchema(config, connection).createAndSetIfNeeded();
   }
 
   private String trim(String dbSchema) {
@@ -52,6 +56,7 @@ final class MigrationSchema {
     }
   }
 
+  @SuppressWarnings("SqlDialectInspection")
   private void createSchemaIfNeeded() throws SQLException {
     if (!schemaExists()) {
       log.log(INFO, "Creating schema: {0}", dbSchema);

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationEarlyModeTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationEarlyModeTest.java
@@ -47,6 +47,7 @@ class MigrationEarlyModeTest {
     config.setDbPassword(pw);
     config.setMigrationPath("dbmig_postgres_early");
     config.setRunPlaceholderMap(Map.of("my_table_name", "my_table"));
+    config.setFastMode(true);
 
     // legacy mode
     new MigrationRunner(config).run(dataSource);

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationSchemaTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationSchemaTest.java
@@ -16,8 +16,7 @@ public class MigrationSchemaTest {
 
     Connection connection = config.createConnection();
 
-    MigrationSchema migrationSchema = new MigrationSchema(config, connection);
-    migrationSchema.createAndSetIfNeeded();
+    MigrationSchema.createIfNeeded(config, connection);
   }
 
   private MigrationConfig createMigrationConfig() {


### PR DESCRIPTION
```java
  /**
   * Set true to enable fastMode. This will perform an initial check for the exact same number
   * of migrations and matching checksums without any locking. If anything does not match
   * then the normal migration is performed with appropriate locking etc.
   */
  public void setFastMode(boolean fastMode)
```

This can be used to speed up the common case that there are no actual migrations to run (all migrations match). 

If there is the same number of migrations (no new ones, all checksums match) then it can stop there.

This is "fast" in that it avoids the checks when all the migrations match:
- create the db schema if required
- does the migration table exist
- lock the migration table

