### PR TITLE
Refactor fastCheck, move startMs and move setAutoCommitFalse()

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/runner/FirstCheck.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/FirstCheck.java
@@ -1,0 +1,89 @@
+package io.ebean.migration.runner;
+
+import io.ebean.migration.MigrationConfig;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * First initial check to see if migrations exist and exactly match.
+ */
+final class FirstCheck {
+
+  final MigrationConfig config;
+  final MigrationPlatform platform;
+  final Connection connection;
+  final String schema;
+  final String table;
+  final String sqlTable;
+  boolean tableKnownToExist;
+  private int count;
+
+  FirstCheck(MigrationConfig config, Connection connection, MigrationPlatform platform) {
+    this.config = config;
+    this.platform = platform;
+    this.connection = connection;
+    this.schema = config.getDbSchema();
+    this.table = config.getMetaTable();
+    this.sqlTable = schema != null ? schema + '.' + table : table;
+  }
+
+  MigrationTable initTable(boolean checkStateOnly) {
+    return new MigrationTable(this, checkStateOnly);
+  }
+
+  boolean fastModeCheck(List<LocalMigrationResource> versions) {
+    try {
+      final List<MigrationMetaRow> rows = fastRead();
+      tableKnownToExist = !rows.isEmpty();
+      if (rows.size() != versions.size() + 1) {
+        // difference in count of migrations
+        return false;
+      }
+      final Map<String, Integer> dbChecksums = dbChecksumMap(rows);
+      for (LocalMigrationResource local : versions) {
+        Integer dbChecksum = dbChecksums.get(local.key());
+        if (dbChecksum == null) {
+          // no match, unexpected missing migration
+          return false;
+        }
+        int localChecksum = checksumFor(local);
+        if (localChecksum != dbChecksum) {
+          // no match, perhaps repeatable migration change
+          return false;
+        }
+      }
+      // successful fast check
+      count = versions.size();
+      return true;
+    } catch (SQLException e) {
+      // probably migration table does not exist
+      return false;
+    }
+  }
+
+  private static Map<String, Integer> dbChecksumMap(List<MigrationMetaRow> rows) {
+    return rows.stream().collect(Collectors.toMap(MigrationMetaRow::version, MigrationMetaRow::checksum));
+  }
+
+  private int checksumFor(LocalMigrationResource local) {
+    if (local instanceof LocalUriMigrationResource) {
+      return ((LocalUriMigrationResource) local).checksum();
+    } else if (local instanceof LocalDdlMigrationResource) {
+      return Checksum.calculate(local.content());
+    } else {
+      return ((LocalJdbcMigrationResource) local).checksum();
+    }
+  }
+
+  List<MigrationMetaRow> fastRead() throws SQLException {
+    return platform.fastReadMigrations(sqlTable, connection);
+  }
+
+  int count() {
+    return count;
+  }
+}

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable1Test.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable1Test.java
@@ -42,6 +42,12 @@ public class MigrationTable1Test {
     dataSource.shutdown();
   }
 
+
+  private MigrationTable migrationTable(Connection conn) {
+    var fc = new FirstCheck(config, conn, platform);
+    return new MigrationTable(fc, false);
+  }
+
   @Test
   public void testMigrationTableBase() throws Exception {
 
@@ -50,7 +56,7 @@ public class MigrationTable1Test {
     MigrationRunner runner = new MigrationRunner(config);
     runner.run(dataSource);
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      MigrationTable table = migrationTable(conn);
       table.createIfNeededAndLock();
       assertThat(table.versions()).containsExactly("hello", "1.1", "1.2", "1.2.1", "m2_view");
 
@@ -68,6 +74,7 @@ public class MigrationTable1Test {
     }
   }
 
+
   @Test
   public void testMigrationTableRepeatableOk() throws Exception {
 
@@ -77,7 +84,7 @@ public class MigrationTable1Test {
     runner.run(dataSource);
 
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      MigrationTable table = migrationTable(conn);
       table.createIfNeededAndLock();
       assertThat(table.versions()).containsExactly("1.1");
       table.unlockMigrationTable();
@@ -90,7 +97,7 @@ public class MigrationTable1Test {
     runner.run(dataSource);
 
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      MigrationTable table = migrationTable(conn);
       table.createIfNeededAndLock();
       assertThat(table.versions()).containsExactly("1.1", "1.2", "m2_view");
       table.unlockMigrationTable();
@@ -108,7 +115,7 @@ public class MigrationTable1Test {
     runner.run(dataSource);
 
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      MigrationTable table = migrationTable(conn);
       table.createIfNeededAndLock();
       assertThat(table.versions()).containsExactly("1.1");
       table.unlockMigrationTable();
@@ -141,7 +148,7 @@ public class MigrationTable1Test {
       assertThat(m3Content).contains("text with ; sign");
 
       // we expect, that 1.1 and 1.2 is executed (but not the R__ script)
-      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      MigrationTable table = migrationTable(conn);
       table.createIfNeededAndLock();
       assertThat(table.versions()).containsExactly("1.1", "1.2");
       conn.rollback();

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable2Test.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTable2Test.java
@@ -10,13 +10,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MigrationTable2Test {
 
+
+  private static MigrationTable migrationTable(MigrationConfig config) {
+    var fc = new FirstCheck(config, null, new MigrationPlatform());
+    return new MigrationTable(fc, false);
+  }
+
   @Test
   void testCreateTableDdl() throws Exception {
 
     MigrationConfig config = new MigrationConfig();
     config.setDbSchema("foo");
 
-    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
+    MigrationTable mt = migrationTable(config);
     String tableSql = mt.createTableDdl();
 
     assertThat(tableSql).contains("create table foo.db_migration ");
@@ -30,7 +36,7 @@ public class MigrationTable2Test {
     config.setDbSchema("bar");
     config.setPlatform(DbPlatformNames.SQLSERVER);
 
-    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
+    MigrationTable mt = migrationTable(config);
     String tableSql = mt.createTableDdl();
 
     assertThat(tableSql).contains("datetime2 ");
@@ -46,7 +52,7 @@ public class MigrationTable2Test {
     LocalMigrationResource local = local("R__hello");
     MigrationMetaRow existing = new MigrationMetaRow(12, "R", "", "comment", 42, null, null, 0);
 
-    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
+    MigrationTable mt = migrationTable(config);
     // checksum different - no skip
     assertFalse(mt.skipMigration(100, 100, local, existing));
     // checksum same - skip
@@ -59,7 +65,7 @@ public class MigrationTable2Test {
     MigrationConfig config = new MigrationConfig();
     config.setSkipChecksum(true);
 
-    MigrationTable mt = new MigrationTable(config, null, false, new MigrationPlatform());
+    MigrationTable mt = migrationTable(config);
 
     // skip regardless of checksum difference
     LocalMigrationResource local = local("R__hello");

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableAsyncTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableAsyncTest.java
@@ -185,7 +185,7 @@ public class MigrationTableAsyncTest {
 
         config.setPlatform(derivedPlatformName);
         MigrationPlatform platform = DbNameUtil.platform(derivedPlatformName);
-        MigrationTable table = migrationTable(platform);
+        MigrationTable table = migrationTable(platform, conn);
         table.createIfNeededAndLock();
         table.unlockMigrationTable();
         conn.commit();
@@ -203,8 +203,8 @@ public class MigrationTableAsyncTest {
     }
   }
 
-  private static MigrationTable migrationTable(MigrationPlatform platform) {
-    var fc = new FirstCheck(config, null, platform);
+  private static MigrationTable migrationTable(MigrationPlatform platform, Connection connection) {
+    var fc = new FirstCheck(config, connection, platform);
     return new MigrationTable(fc, false);
   }
 

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableAsyncTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableAsyncTest.java
@@ -185,7 +185,7 @@ public class MigrationTableAsyncTest {
 
         config.setPlatform(derivedPlatformName);
         MigrationPlatform platform = DbNameUtil.platform(derivedPlatformName);
-        MigrationTable table = new MigrationTable(config, conn, false, platform);
+        MigrationTable table = migrationTable(platform);
         table.createIfNeededAndLock();
         table.unlockMigrationTable();
         conn.commit();
@@ -201,6 +201,11 @@ public class MigrationTableAsyncTest {
     for (Future<String> future : futures) {
       assertThat(future.get()).isEqualTo("OK");
     }
+  }
+
+  private static MigrationTable migrationTable(MigrationPlatform platform) {
+    var fc = new FirstCheck(config, null, platform);
+    return new MigrationTable(fc, false);
   }
 
   private void dropTable(String tableName) throws SQLException {

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableCreateTableRaceTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableCreateTableRaceTest.java
@@ -51,7 +51,8 @@ class MigrationTableCreateTableRaceTest {
     try (Connection conn = dataSource.getConnection()) {
       dropTable(conn);
 
-      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      var fc = new FirstCheck(config, conn, platform);
+      MigrationTable table = new MigrationTable(fc, false);
       table.createTable();
       try {
         // simulate losing the race, this createTable() will fail as the table exists

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableTestDb2.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableTestDb2.java
@@ -15,7 +15,7 @@ public class MigrationTableTestDb2 {
 
   private static MigrationConfig config;
   private static DataSourcePool dataSource;
-  private MigrationPlatform platform = new MigrationPlatform();
+  private final MigrationPlatform platform = new MigrationPlatform();
 
   @BeforeEach
   public void setUp() {
@@ -44,7 +44,8 @@ public class MigrationTableTestDb2 {
     config.setMigrationPath("dbmig");
 
     try (Connection conn = dataSource.getConnection()) {
-      MigrationTable table = new MigrationTable(config, conn, false, platform);
+      var fc = new FirstCheck(config, conn, platform);
+      MigrationTable table = new MigrationTable(fc, false);
       table.createIfNeededAndLock();
       table.unlockMigrationTable();
       table.createIfNeededAndLock();


### PR DESCRIPTION
- Move startMs to be before the resource loading (include that in the time)
- Move the setAutoCommitFalse() to occur after fastCheck query (nb: the fast check query will rollback() if executed
- Move fast check logic into FirstCheck class
- Rename method derivePlatformName() -> derivePlatform())
- Change MigrationTable constructor to task FirstCheck