### PR TITLE
Fix support java migrations with index

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/runner/LocalMigrationResources.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/LocalMigrationResources.java
@@ -90,8 +90,16 @@ final class LocalMigrationResources {
             final var location = pair[1].trim();
             final var substring = location.substring(0, location.length() - 4);
             final var version = MigrationVersion.parse(substring);
-            final var url = resource(base + location);
-            versions.add(new LocalUriMigrationResource(version, location, url, checksum));
+            if (location.endsWith(".class")) {
+              String className = base.replace('/', '.').substring(1)
+                + location.substring(0, location.length() - 6);
+              JdbcMigration instance = migrationConfig.getJdbcMigrationFactory().createInstance(className);
+              assert instance.getChecksum() == checksum;
+              versions.add(new LocalJdbcMigrationResource(version, location, instance));
+            } else {
+              final var url = resource(base + location);
+              versions.add(new LocalUriMigrationResource(version, location, url, checksum));
+            }
           }
         }
       }

--- a/ebean-migration/src/test/java/dbmig_idx/V1_2_1__test.java
+++ b/ebean-migration/src/test/java/dbmig_idx/V1_2_1__test.java
@@ -1,11 +1,11 @@
-package dbmig;
-
-import java.sql.Connection;
+package dbmig_idx;
 
 import io.ebean.migration.ConfigurationAware;
 import io.ebean.migration.JdbcMigration;
 import io.ebean.migration.MigrationConfig;
 import io.ebean.migration.MigrationRunnerTest;
+
+import java.sql.Connection;
 
 /**
  * Sample migration.
@@ -20,7 +20,7 @@ public class V1_2_1__test implements JdbcMigration, ConfigurationAware{
   public static class MyDto {
     String id;
   }
-  
+
   @Override
   public void setMigrationConfig(MigrationConfig config) {
     this.config = config;

--- a/ebean-migration/src/test/java/io/ebean/migration/MigrationRunnerTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/MigrationRunnerTest.java
@@ -44,7 +44,7 @@ public class MigrationRunnerTest {
     assertThat(check.get(0).content()).contains("-- do nothing");
     assertThat(check.get(1).content()).contains("create table m1");
     assertThat(check.get(2).content()).contains("create table m3");
-    assertThat(check.get(3).location()).isEqualTo("dbmig_idx/V1_2_1__test.class");
+    assertThat(check.get(3).location()).isEqualTo("dbmig/V1_2_1__test.class");
     assertThat(javaMigrationExecuted).isFalse();
     runner.run();
     assertThat(javaMigrationExecuted).isTrue();

--- a/ebean-migration/src/test/java/io/ebean/migration/MigrationRunnerTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/MigrationRunnerTest.java
@@ -28,22 +28,46 @@ public class MigrationRunnerTest {
     return config;
   }
 
+  public static boolean javaMigrationExecuted;
+
   @Test
   public void run_when_createConnection() {
 
+    javaMigrationExecuted = false;
     MigrationConfig config = createMigrationConfig();
 
     config.setMigrationPath("dbmig");
     MigrationRunner runner = new MigrationRunner(config);
-
     List<MigrationResource> check = runner.checkState();
     assertThat(check).hasSize(5);
 
     assertThat(check.get(0).content()).contains("-- do nothing");
     assertThat(check.get(1).content()).contains("create table m1");
     assertThat(check.get(2).content()).contains("create table m3");
-
+    assertThat(check.get(3).location()).isEqualTo("dbmig_idx/V1_2_1__test.class");
+    assertThat(javaMigrationExecuted).isFalse();
     runner.run();
+    assertThat(javaMigrationExecuted).isTrue();
+  }
+
+  @Test
+  public void win_with_idx_file() {
+
+    javaMigrationExecuted = false;
+    MigrationConfig config = createMigrationConfig();
+
+    config.setMigrationPath("dbmig_idx");
+    MigrationRunner runner = new MigrationRunner(config);
+    List<MigrationResource> check = runner.checkState();
+    assertThat(check).hasSize(5);
+
+    assertThat(check.get(0).content()).contains("-- do nothing");
+    assertThat(check.get(1).content()).contains("create table m1");
+    assertThat(check.get(2).content()).contains("create table m3");
+    assertThat(check.get(3).location()).isEqualTo("dbmig_idx/V1_2_1__test.class");
+    assertThat(javaMigrationExecuted).isFalse();
+    runner.run();
+    assertThat(javaMigrationExecuted).isTrue();
   }
 
   @Test

--- a/ebean-migration/src/test/resources/dbmig_idx/1.1__initial.sql
+++ b/ebean-migration/src/test/resources/dbmig_idx/1.1__initial.sql
@@ -1,0 +1,5 @@
+create table m1 (id integer, acol varchar(20));
+-- Check with DB2:
+-- call sysproc.admin_cmd('reorg table m1');
+create table m2 (id integer, acol varchar(20), bcol timestamp);
+

--- a/ebean-migration/src/test/resources/dbmig_idx/1.2__add_m3.sql
+++ b/ebean-migration/src/test/resources/dbmig_idx/1.2__add_m3.sql
@@ -1,0 +1,5 @@
+create table m3 (id integer, acol varchar(20), bcol timestamp);
+
+alter table m1 add column addcol varchar(10);
+
+insert into m3 (id, acol) VALUES (1, 'text with ; sign'); -- plus some comment

--- a/ebean-migration/src/test/resources/dbmig_idx/I__hello.sql
+++ b/ebean-migration/src/test/resources/dbmig_idx/I__hello.sql
@@ -1,0 +1,1 @@
+-- do nothing

--- a/ebean-migration/src/test/resources/dbmig_idx/R__m2_view.sql
+++ b/ebean-migration/src/test/resources/dbmig_idx/R__m2_view.sql
@@ -1,0 +1,1 @@
+create or replace view m2_vw as select id, acol from m2;

--- a/ebean-migration/src/test/resources/dbmig_idx/idx_h2.migrations
+++ b/ebean-migration/src/test/resources/dbmig_idx/idx_h2.migrations
@@ -1,0 +1,5 @@
+-423501496,     I__hello.sql
+-250044392,     1.1__initial.sql
+531446402,      1.2__add_m3.sql
+0,              V1_2_1__test.class
+-846848863,     R__m2_view.sql


### PR DESCRIPTION
Hello Rob,
with #91 the ebean-migration does not scan the classpath for java migrations. There are currently 2 issues
1. When Ebean generates migrations, it does not add java migrations to the idx file (PR will follow)
2. Ebean-migration does not support java migrations in the idx file.

This PR adds java-migration support for idx files.
Furthermore, this change may make #90 obsolete (the java class to use is defined in the idx file now)