### PR TITLE
Shut down datasources in tests

### DIFF
--- a/ebean-migration/src/test/java/io/ebean/migration/AutoRunnerTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/AutoRunnerTest.java
@@ -24,17 +24,20 @@ class AutoRunnerTest {
     dataSourceConfig.setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
+    try {
+      Properties properties = new Properties();
+      properties.setProperty("dbmigration.migrationPath", "dbmig_autorun");
 
-    Properties properties = new Properties();
-    properties.setProperty("dbmigration.migrationPath","dbmig_autorun");
-
-    AutoRunner autoRunner = new AutoRunner();
-    autoRunner.setDefaultDbSchema("other");
-    autoRunner.loadProperties(properties);
-    autoRunner.run(dataSource);
+      AutoRunner autoRunner = new AutoRunner();
+      autoRunner.setDefaultDbSchema("other");
+      autoRunner.loadProperties(properties);
+      autoRunner.run(dataSource);
 
 
-    assertTrue(executeQuery(dataSource));
+      assertTrue(executeQuery(dataSource));
+    } finally {
+      dataSource.shutdown();
+    }
   }
 
   private boolean executeQuery(DataSourcePool dataSource) throws SQLException {

--- a/ebean-migration/src/test/java/io/ebean/migration/MigrationRunnerTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/MigrationRunnerTest.java
@@ -84,6 +84,8 @@ public class MigrationRunnerTest {
           fail(ex);
         }
       }
+    } finally {
+      dataSource.shutdown();
     }
   }
 
@@ -108,39 +110,41 @@ public class MigrationRunnerTest {
     dataSourceConfig.setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
+    try {
+      MigrationConfig config = createMigrationConfig();
+      config.setMigrationPath("dbmig");
 
-    MigrationConfig config = createMigrationConfig();
-    config.setMigrationPath("dbmig");
+      MigrationRunner runner = new MigrationRunner(config);
+      runner.run(dataSource);
+      System.out.println("-- run second time --");
+      runner.run(dataSource);
 
-    MigrationRunner runner = new MigrationRunner(config);
-    runner.run(dataSource);
-    System.out.println("-- run second time --");
-    runner.run(dataSource);
+      // simulate change to repeatable migration
+      config.setMigrationPath("dbmig3");
+      System.out.println("-- run third time --");
+      runner.run(dataSource);
 
-    // simulate change to repeatable migration
-    config.setMigrationPath("dbmig3");
-    System.out.println("-- run third time --");
-    runner.run(dataSource);
+      config.setMigrationPath("dbmig4");
 
-    config.setMigrationPath("dbmig4");
+      config.setPatchResetChecksumOn("m2_view,1.2");
+      List<MigrationResource> checkState = runner.checkState(dataSource);
+      assertThat(checkState).hasSize(1);
+      assertThat(checkState.get(0).version().asString()).isEqualTo("1.3");
 
-    config.setPatchResetChecksumOn("m2_view,1.2");
-    List<MigrationResource> checkState = runner.checkState(dataSource);
-    assertThat(checkState).hasSize(1);
-    assertThat(checkState.get(0).version().asString()).isEqualTo("1.3");
+      config.setPatchInsertOn("1.3");
+      checkState = runner.checkState(dataSource);
+      assertThat(checkState).isEmpty();
 
-    config.setPatchInsertOn("1.3");
-    checkState = runner.checkState(dataSource);
-    assertThat(checkState).isEmpty();
+      System.out.println("-- run forth time --");
+      runner.run(dataSource);
 
-    System.out.println("-- run forth time --");
-    runner.run(dataSource);
-
-    System.out.println("-- run fifth time --");
-    checkState = runner.checkState(dataSource);
-    assertThat(checkState).isEmpty();
-    runner.run(dataSource);
-
+      System.out.println("-- run fifth time --");
+      checkState = runner.checkState(dataSource);
+      assertThat(checkState).isEmpty();
+      runner.run(dataSource);
+    } finally {
+      dataSource.shutdown();
+    }
   }
 
   @Test
@@ -153,21 +157,24 @@ public class MigrationRunnerTest {
     dataSourceConfig.setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
+    try {
+      MigrationConfig config = createMigrationConfig();
+      config.setDbUrl("jdbc:h2:mem:testsDbInit");
+      config.setMigrationPath("dbmig5_base");
+      config.setMigrationInitPath("dbmig5_init");
 
-    MigrationConfig config = createMigrationConfig();
-    config.setDbUrl("jdbc:h2:mem:testsDbInit");
-    config.setMigrationPath("dbmig5_base");
-    config.setMigrationInitPath("dbmig5_init");
+      MigrationRunner runner = new MigrationRunner(config);
+      runner.run(dataSource);
 
-    MigrationRunner runner = new MigrationRunner(config);
-    runner.run(dataSource);
+      MigrationRunner runner2 = new MigrationRunner(config);
+      runner2.run(dataSource);
 
-    MigrationRunner runner2 = new MigrationRunner(config);
-    runner2.run(dataSource);
-
-    try (final Connection connection = dataSource.getConnection()) {
-      final List<String> names = migrationNames(connection);
-      assertThat(names).containsExactly("<init>", "some_i", "m4", "some_r");
+      try (final Connection connection = dataSource.getConnection()) {
+        final List<String> names = migrationNames(connection);
+        assertThat(names).containsExactly("<init>", "some_i", "m4", "some_r");
+      }
+    } finally {
+      dataSource.shutdown();
     }
   }
 
@@ -180,21 +187,24 @@ public class MigrationRunnerTest {
     dataSourceConfig.setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
+    try {
+      MigrationConfig config = createMigrationConfig();
+      config.setDbUrl("jdbc:h2:mem:testsDbInit2");
+      config.setMigrationPath("dbmig6_base");
+      config.setMigrationInitPath("dbmig6_init");
 
-    MigrationConfig config = createMigrationConfig();
-    config.setDbUrl("jdbc:h2:mem:testsDbInit2");
-    config.setMigrationPath("dbmig6_base");
-    config.setMigrationInitPath("dbmig6_init");
+      MigrationRunner runner = new MigrationRunner(config);
+      runner.run(dataSource);
 
-    MigrationRunner runner = new MigrationRunner(config);
-    runner.run(dataSource);
+      MigrationRunner runner2 = new MigrationRunner(config);
+      runner2.run(dataSource);
 
-    MigrationRunner runner2 = new MigrationRunner(config);
-    runner2.run(dataSource);
-
-    try (final Connection connection = dataSource.getConnection()) {
-      final List<String> names = migrationNames(connection);
-      assertThat(names).containsExactly("<init>", "m4");
+      try (final Connection connection = dataSource.getConnection()) {
+        final List<String> names = migrationNames(connection);
+        assertThat(names).containsExactly("<init>", "m4");
+      }
+    } finally {
+      dataSource.shutdown();
     }
   }
 
@@ -208,30 +218,33 @@ public class MigrationRunnerTest {
     dataSourceConfig.setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
+    try {
+      MigrationConfig config = createMigrationConfig();
+      config.setMigrationPath("dbmig");
+      config.setMinVersion("1.3"); // dbmig must run, if DB is empty!
+      new MigrationRunner(config).run(dataSource);
 
-    MigrationConfig config = createMigrationConfig();
-    config.setMigrationPath("dbmig");
-    config.setMinVersion("1.3"); // dbmig must run, if DB is empty!
-    new MigrationRunner(config).run(dataSource);
 
+      config = createMigrationConfig();
+      config.setMigrationPath("dbmig3");
+      config.setMinVersion("1.3");
+      config.setMinVersionFailMessage("Must run dbmig2 first.");
 
-    config = createMigrationConfig();
-    config.setMigrationPath("dbmig3");
-    config.setMinVersion("1.3");
-    config.setMinVersionFailMessage("Must run dbmig2 first.");
+      MigrationRunner runner3 = new MigrationRunner(config);
+      assertThatThrownBy(() -> runner3.run(dataSource))
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("Must run dbmig2 first. MigrationVersion mismatch: v1.2.1 < v1.3");
 
-    MigrationRunner runner3 = new MigrationRunner(config);
-    assertThatThrownBy(() -> runner3.run(dataSource))
-      .isInstanceOf(MigrationException.class)
-      .hasMessageContaining("Must run dbmig2 first. MigrationVersion mismatch: v1.2.1 < v1.3");
+      // now run dbmig2, as intended by error message
+      config = createMigrationConfig();
+      config.setMigrationPath("dbmig2");
+      new MigrationRunner(config).run(dataSource);
 
-    // now run dbmig2, as intended by error message
-    config = createMigrationConfig();
-    config.setMigrationPath("dbmig2");
-    new MigrationRunner(config).run(dataSource);
-
-    // dbmig3 should pass now
-    runner3.run(dataSource);
+      // dbmig3 should pass now
+      runner3.run(dataSource);
+    } finally {
+      dataSource.shutdown();
+    }
   }
 
   @Test
@@ -244,23 +257,26 @@ public class MigrationRunnerTest {
     dataSourceConfig.setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
+    try {
+      // init
+      MigrationConfig config = createMigrationConfig();
+      config.setMigrationPath("dbmig5_base");
+      config.setMigrationInitPath("dbmig5_init");
+      config.setMinVersion("2.0"); // init must run, although DB is empty!
+      new MigrationRunner(config).run(dataSource);
 
-    // init
-    MigrationConfig config = createMigrationConfig();
-    config.setMigrationPath("dbmig5_base");
-    config.setMigrationInitPath("dbmig5_init");
-    config.setMinVersion("2.0"); // init must run, although DB is empty!
-    new MigrationRunner(config).run(dataSource);
+      // test if migration detects correct init-version (1.3)
+      config = createMigrationConfig();
+      config.setMigrationPath("dbmig3");
+      config.setMinVersion("2.0");
 
-    // test if migration detects correct init-version (1.3)
-    config = createMigrationConfig();
-    config.setMigrationPath("dbmig3");
-    config.setMinVersion("2.0");
-
-    MigrationRunner runner = new MigrationRunner(config);
-    assertThatThrownBy(() -> runner.run(dataSource))
-      .isInstanceOf(MigrationException.class)
-      .hasMessageContaining("MigrationVersion mismatch: v1.3 < v2.0");
+      MigrationRunner runner = new MigrationRunner(config);
+      assertThatThrownBy(() -> runner.run(dataSource))
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("MigrationVersion mismatch: v1.3 < v2.0");
+    } finally {
+      dataSource.shutdown();
+    }
   }
 
   @Test
@@ -278,20 +294,24 @@ public class MigrationRunnerTest {
     config.setMigrationPath("dbmig");
 
     DataSourcePool dataSource = DataSourceFactory.create("skipMigration", dataSourceConfig);
-    new MigrationRunner(config).run(dataSource);
+    try {
+      new MigrationRunner(config).run(dataSource);
 
-    // assert migrations are in the migration table
-    try (final Connection connection = dataSource.getConnection()) {
-      final List<String> names = migrationNames(connection);
-      assertThat(names).contains("<init>", "hello", "initial", "add_m3", "test", "m2_view");
-    }
+      // assert migrations are in the migration table
+      try (final Connection connection = dataSource.getConnection()) {
+        final List<String> names = migrationNames(connection);
+        assertThat(names).contains("<init>", "hello", "initial", "add_m3", "test", "m2_view");
+      }
 
-    // assert the migrations didn't actually run (create the tables etc)
-    try (final Connection connection = dataSource.getConnection()) {
-      singleQueryResult(connection, "select acol from m3");
-      fail();
-    } catch (SQLException e) {
-      assertThat(e.getMessage()).contains("Table \"M3\" not found;");
+      // assert the migrations didn't actually run (create the tables etc)
+      try (final Connection connection = dataSource.getConnection()) {
+        singleQueryResult(connection, "select acol from m3");
+        fail();
+      } catch (SQLException e) {
+        assertThat(e.getMessage()).contains("Table \"M3\" not found;");
+      }
+    } finally {
+      dataSource.shutdown();
     }
   }
 

--- a/ebean-migration/src/test/java/io/ebean/migration/MigrationRunner_PatchResetTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/MigrationRunner_PatchResetTest.java
@@ -17,20 +17,22 @@ class MigrationRunner_PatchResetTest {
       .setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test", dataSourceConfig);
+    try {
+      MigrationConfig config = new MigrationConfig();
+      config.setPlatform("h2");
 
-    MigrationConfig config = new MigrationConfig();
-    config.setPlatform("h2");
+      config.setMigrationPath("indexPatchReset_0");
+      MigrationRunner runner = new MigrationRunner(config);
+      runner.run(dataSource);
 
-    config.setMigrationPath("indexPatchReset_0");
-    MigrationRunner runner = new MigrationRunner(config);
-    runner.run(dataSource);
+      // add an index file now, expect automatically go to early mode + patch checksums
+      config.setMigrationPath("indexPatchReset_1");
+      config.setPatchResetChecksumOn("*");
+      new MigrationRunner(config).run(dataSource);
 
-    // add an index file now, expect automatically go to early mode + patch checksums
-    config.setMigrationPath("indexPatchReset_1");
-    config.setPatchResetChecksumOn("*");
-    new MigrationRunner(config).run(dataSource);
-
-    dataSource.shutdown();
+    } finally {
+      dataSource.shutdown();
+    }
   }
 
 }

--- a/ebean-migration/src/test/java/io/ebean/migration/MigrationRunner_emptyTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/MigrationRunner_emptyTest.java
@@ -16,14 +16,15 @@ class MigrationRunner_emptyTest {
     dataSourceConfig.setPassword("");
 
     DataSourcePool dataSource = DataSourceFactory.create("test-empty", dataSourceConfig);
+    try {
+      MigrationConfig config = new MigrationConfig();
+      config.setMigrationPath("empty-dbmig");
 
-    MigrationConfig config = new MigrationConfig();
-    config.setMigrationPath("empty-dbmig");
-
-    MigrationRunner runner = new MigrationRunner(config);
-    runner.run(dataSource);
-
-    dataSource.shutdown();
+      MigrationRunner runner = new MigrationRunner(config);
+      runner.run(dataSource);
+    } finally {
+      dataSource.shutdown();
+    }
   }
 
 }

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationEarlyModeTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationEarlyModeTest.java
@@ -9,14 +9,9 @@ import io.ebean.migration.MigrationRunner;
 import io.ebean.test.containers.PostgresContainer;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.util.Map;
 
 import static java.lang.System.Logger.Level.INFO;
-import static org.assertj.core.api.Assertions.fail;
 
 class MigrationEarlyModeTest {
 
@@ -40,39 +35,43 @@ class MigrationEarlyModeTest {
 
     String url = createPostgres().jdbcUrl();
     DataSourcePool dataSource = dataSource(url);
+    try {
 
-    MigrationConfig config = new MigrationConfig();
-    config.setDbUrl(url);
-    config.setDbUsername(un);
-    config.setDbPassword(pw);
-    config.setMigrationPath("dbmig_postgres_early");
-    config.setRunPlaceholderMap(Map.of("my_table_name", "my_table"));
-    config.setFastMode(true);
+      MigrationConfig config = new MigrationConfig();
+      config.setDbUrl(url);
+      config.setDbUsername(un);
+      config.setDbPassword(pw);
+      config.setMigrationPath("dbmig_postgres_early");
+      config.setRunPlaceholderMap(Map.of("my_table_name", "my_table"));
+      config.setFastMode(true);
 
-    // legacy mode
-    new MigrationRunner(config).run(dataSource);
+      // legacy mode
+      new MigrationRunner(config).run(dataSource);
 
-    // early mode
-    log.log(INFO, "-- EARLY MODE -- ");
-    config.setEarlyChecksumMode(true);
-    new MigrationRunner(config).run(dataSource);
+      // early mode
+      log.log(INFO, "-- EARLY MODE -- ");
+      config.setEarlyChecksumMode(true);
+      new MigrationRunner(config).run(dataSource);
 
-    log.log(INFO, "-- RE-RUN EARLY MODE -- ");
-    new MigrationRunner(config).run(dataSource);
+      log.log(INFO, "-- RE-RUN EARLY MODE -- ");
+      new MigrationRunner(config).run(dataSource);
 
-    log.log(INFO, "-- LEGACY MODE AGAIN (will auto detect early mode) -- ");
-    config.setEarlyChecksumMode(false);
-    new MigrationRunner(config).run(dataSource);
+      log.log(INFO, "-- LEGACY MODE AGAIN (will auto detect early mode) -- ");
+      config.setEarlyChecksumMode(false);
+      new MigrationRunner(config).run(dataSource);
 
-    log.log(INFO, "-- LEGACY MODE with more migrations -- ");
+      log.log(INFO, "-- LEGACY MODE with more migrations -- ");
 
-    config.setRunPlaceholderMap(Map.of("my_table_name", "my_table", "other_table_name", "other"));
-    config.setMigrationPath("dbmig_postgres_early1");
-    new MigrationRunner(config).run(dataSource);
+      config.setRunPlaceholderMap(Map.of("my_table_name", "my_table", "other_table_name", "other"));
+      config.setMigrationPath("dbmig_postgres_early1");
+      new MigrationRunner(config).run(dataSource);
 
-    log.log(INFO, "-- EARLY MODE again -- ");
-    config.setEarlyChecksumMode(true);
-    new MigrationRunner(config).run(dataSource);
+      log.log(INFO, "-- EARLY MODE again -- ");
+      config.setEarlyChecksumMode(true);
+      new MigrationRunner(config).run(dataSource);
+    } finally {
+      dataSource.shutdown();
+    }
 
   }
 

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableCreateTableRaceTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationTableCreateTableRaceTest.java
@@ -65,6 +65,8 @@ class MigrationTableCreateTableRaceTest {
       }
       // cleanup
       dropTable(conn);
+    } finally {
+      dataSource.shutdown();
     }
   }
 


### PR DESCRIPTION
I noticed, that datasources are created, which aren't shut down.
This causes JUnit to wait up to 30 seconds after the last test was executed before it will kill the VM

**Before this change**

```
$ mvn test

// sometimes this error occurs:
[ERROR] Surefire is going to kill self fork JVM. The exit has elapsed 30 seconds after System.exit(0).

Tests run: 72
Total time:  46.631 s
```

**After this change**
```
$ mvn test

Tests run: 72
Total time:  14.866 s
```

This PR has only changes in test code