### PR TITLE
Change fastMode to default to true

### DIFF
--- a/ebean-migration/src/main/java/io/ebean/migration/MigrationConfig.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/MigrationConfig.java
@@ -66,7 +66,7 @@ public class MigrationConfig {
   private String platform;
   private Properties properties;
   private boolean earlyChecksumMode;
-  private boolean fastMode;
+  private boolean fastMode = true;
 
   /**
    * Return the name of the migration table.


### PR DESCRIPTION
When fastMode is true then the migration runner will perform a fast test that all migrations have been run and can fast exit if this is true. If this test fails for any reason then the usual execution occurs.

The fastMode defaulting to true is reasonable because commonly the migration is run on application startup and most often there is no change to migrations.