### PR TITLE
Fix bug where db schema isn't set on subsequent migrations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java_version }}
         distribution: 'zulu'
     - name: Maven cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: maven-cache
       with:

--- a/ebean-migration/pom.xml
+++ b/ebean-migration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>4.0</version>
+    <version>5.1</version>
     <relativePath />
   </parent>
 
@@ -22,6 +22,12 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.17</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-applog</artifactId>
@@ -134,23 +140,23 @@ mvn install:install-file -Dfile=/some/path/to/ojdbc7.jar -DgroupId=oracle \
     <!--    </dependency>-->
 
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.5.2</version>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-simple-logger</artifactId>
+      <version>0.5</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test-containers</artifactId>
-      <version>7.3</version>
+      <version>7.14</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.4</version>
+      <version>1.6</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationSchema.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationSchema.java
@@ -37,6 +37,16 @@ final class MigrationSchema {
     new MigrationSchema(config, connection).createAndSetIfNeeded();
   }
 
+  static void setIfNeeded(MigrationConfig config, Connection connection) throws SQLException {
+    new MigrationSchema(config, connection).setSchemaIfNeeded();
+  }
+
+  private void setSchemaIfNeeded() throws SQLException {
+    if (dbSchema != null && setCurrentSchema) {
+       setSchema();
+    }
+  }
+
   private String trim(String dbSchema) {
     return (dbSchema == null) ? null : dbSchema.trim();
   }

--- a/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
+++ b/ebean-migration/src/main/java/io/ebean/migration/runner/MigrationTable.java
@@ -141,7 +141,9 @@ final class MigrationTable {
    */
   void createIfNeededAndLock() throws SQLException, IOException {
     SQLException suppressedException = null;
-    if (!tableKnownToExist) {
+    if (tableKnownToExist) {
+      MigrationSchema.setIfNeeded(config, context.connection());
+    } else {
       MigrationSchema.createIfNeeded(config, context.connection());
       if (!tableExists()) {
         try {

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationPostgresSchemaTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationPostgresSchemaTest.java
@@ -1,0 +1,58 @@
+package io.ebean.migration.runner;
+
+import io.ebean.migration.MigrationConfig;
+import io.ebean.migration.MigrationRunner;
+import io.ebean.test.containers.PostgresContainer;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+class MigrationPostgresSchemaTest {
+
+  private static PostgresContainer createPostgres() {
+    return PostgresContainer.builder("17")
+      .port(0) // random port
+      .containerName("pg17_temp")
+      .user("mig_exp_schema")
+      .password("mig_exp_schema")
+      .dbName("mig_exp_schema")
+      .build();
+  }
+
+  @Test
+  void runTwice_expect_setSchemaCalled() throws SQLException {
+    PostgresContainer postgresContainer = createPostgres();
+    postgresContainer.stopRemove();
+    postgresContainer.start();
+
+
+    MigrationConfig config = new MigrationConfig();
+    config.setDbUrl(postgresContainer.jdbcUrl());
+    config.setDbUsername("mig_exp_schema");
+    config.setDbPassword("mig_exp_schema");
+    config.setDbSchema("bar");
+
+    // first run, creates and sets the schema correctly (no issue here)
+    config.setMigrationPath("dbmig");
+    MigrationRunner runner = new MigrationRunner(config);
+    runner.run();
+
+    // run again, SHOULD set the schema (this is where the bug is)
+    config.setMigrationPath("dbmig2");
+    MigrationRunner runner2 = new MigrationRunner(config);
+    runner2.run();
+
+    // make sure the m4 table was created in the bar schema
+    try (Connection connection = config.createConnection()) {
+      try (PreparedStatement stmt = connection.prepareStatement("select * from bar.m4")) {
+        try (ResultSet resultSet = stmt.executeQuery()) {
+          resultSet.next();
+        }
+      }
+    }
+  }
+
+}

--- a/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationSchemaTest.java
+++ b/ebean-migration/src/test/java/io/ebean/migration/runner/MigrationSchemaTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 
-public class MigrationSchemaTest {
+class MigrationSchemaTest {
 
   @Test
   void testCreateAndSetIfNeeded() throws Exception {
@@ -14,13 +14,12 @@ public class MigrationSchemaTest {
     config.setDbSchema("SOME_NEW_SCHEMA");
     config.setCreateSchemaIfNotExists(true);
 
-    Connection connection = config.createConnection();
-
-    MigrationSchema.createIfNeeded(config, connection);
+    try (Connection connection = config.createConnection()) {
+      MigrationSchema.createIfNeeded(config, connection);
+    }
   }
 
   private MigrationConfig createMigrationConfig() {
-
     MigrationConfig config = new MigrationConfig();
     config.setDbUsername("sa");
     config.setDbPassword("");

--- a/ebean-migration/src/test/resources/avaje-logger.properties
+++ b/ebean-migration/src/test/resources/avaje-logger.properties
@@ -1,0 +1,7 @@
+logger.format=plain
+
+## default log level to use when running tests
+logger.defaultLogLevel=INFO
+
+## some test specific log levels
+log.level.io.ebean=TRACE

--- a/test-native-image/pom.xml
+++ b/test-native-image/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test-containers</artifactId>
-      <version>7.3</version>
+      <version>7.14</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
The dbSchema was being created and set correctly on the first migration run, but for subsequent migrations the schema was not being set on the connection before running the migration.

This fixes that issue.